### PR TITLE
Retrieve user information

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,12 @@ end
 **User mapping**
 The host app is responsible for mapping a Keycloak session with a Rails user session. This can be achieved
 by implementing the `map_authenticatable` method in the module configured above (e.g. `KeycloakOauthCallbacks` in our example).
-You can get the user information using the `KeycloakOauth::UserInfoRetrievalService` to which you pass in the access token.
+You can get the user information by making a call to `KeycloakOauth.connection.get_user_information` to which you pass in the access token.
 See here an example of retrieving the user information and saving the email address in the Rails session:
 
 ```ruby
 def map_authenticatable(_request)
-  service = KeycloakOauth::UserInfoRetrievalService.new(access_token: session[:access_token])
-  service.retrieve
+  service = KeycloakOauth.connection.get_user_information(access_token: session[:access_token])
   session[:user_email_address] = service.user_information['email']
 end
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ KeycloakOauth.configure do |config|
 end
 ```
 
+**User mapping**
+The host app is responsible for mapping a Keycloak session with a Rails user session. This can be achieved
+by implementing the `map_authenticatable` method in the module configured above (e.g. `KeycloakOauthCallbacks` in our example).
+You can get the user information using the `KeycloakOauth::UserInfoRetrievalService` to which you pass in the access token.
+See here an example of retrieving the user information and saving the email address in the Rails session:
+
+```ruby
+def map_authenticatable(_request)
+  service = KeycloakOauth::UserInfoRetrievalService.new(access_token: session[:access_token])
+  service.retrieve
+  session[:user_email_address] = service.user_information['email']
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/app/controllers/keycloak_oauth/callbacks_controller.rb
+++ b/app/controllers/keycloak_oauth/callbacks_controller.rb
@@ -10,6 +10,7 @@ module KeycloakOauth
         session: session
       )
       authentication_service.authenticate
+      map_authenticatable_if_implemented(session)
 
       redirect_to self.class.method_defined?(:after_sign_in_path) ? after_sign_in_path(request) : '/'
     end
@@ -18,6 +19,14 @@ module KeycloakOauth
 
     def authentication_params
       params.permit(:code)
+    end
+
+    def map_authenticatable_if_implemented(request)
+      if self.class.method_defined?(:map_authenticatable)
+        map_authenticatable(request)
+      else
+        raise NotImplementedError.new('User mapping must be handled by the host app. See README for more information.')
+      end
     end
   end
 end

--- a/app/services/keycloak_oauth/user_info_retrieval_service.rb
+++ b/app/services/keycloak_oauth/user_info_retrieval_service.rb
@@ -1,0 +1,45 @@
+require 'net/http'
+
+module KeycloakOauth
+  class UserInfoRetrievalError < StandardError; end
+
+  class UserInfoRetrievalService
+    AUTHORIZATION_HEADER = 'Authorization'.freeze
+    CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
+
+    attr_reader :user_information
+
+    def initialize(access_token:)
+      @access_token = access_token
+    end
+
+    def retrieve
+      @user_information = parsed_user_information(get_user)
+    end
+
+    private
+
+    attr_accessor :access_token
+
+    def get_user
+      uri = URI.parse(KeycloakOauth.connection.user_info_endpoint)
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        request = Net::HTTP::Get.new(uri)
+        request.set_content_type(CONTENT_TYPE)
+        request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
+        http.request(request)
+      end
+    end
+
+    def parsed_user_information(http_response)
+      response_hash = JSON.parse(http_response.body)
+
+      return response_hash if http_response.code_type == Net::HTTPOK
+
+      # TODO: For now, we assume that the access token is always valid.
+      # We do not yet handle the case where a refresh token is passed in and
+      # used if the access token has expired.
+      raise KeycloakOauth::UserInfoRetrievalError.new(response_hash)
+    end
+  end
+end

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -1,8 +1,10 @@
+require 'keycloak_oauth/endpoints'
+
 module KeycloakOauth
   class Connection
-    attr_reader :auth_url, :realm, :client_id, :client_secret, :callback_module
+    include KeycloakOauth::Endpoints
 
-    DEFAULT_RESPONSE_TYPE = 'code'.freeze
+    attr_reader :auth_url, :realm, :client_id, :client_secret, :callback_module
 
     def initialize(auth_url:, realm:, client_id:, client_secret:, callback_module: nil)
       @auth_url = auth_url
@@ -10,20 +12,6 @@ module KeycloakOauth
       @client_id = client_id
       @client_secret = client_secret
       @callback_module = callback_module
-    end
-
-    def authorization_endpoint(options: {})
-      endpoint = "#{auth_url}/realms/#{realm}/protocol/openid-connect/auth?client_id=#{client_id}"
-      endpoint += "&response_type=#{options[:response_type] || DEFAULT_RESPONSE_TYPE}"
-    end
-
-    def authentication_endpoint
-      "#{auth_url}/realms/#{realm}/protocol/openid-connect/token"
-    end
-
-
-    def user_info_endpoint
-      "#{auth_url}/realms/#{realm}/protocol/openid-connect/userinfo"
     end
   end
 end

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -20,5 +20,10 @@ module KeycloakOauth
     def authentication_endpoint
       "#{auth_url}/realms/#{realm}/protocol/openid-connect/token"
     end
+
+
+    def user_info_endpoint
+      "#{auth_url}/realms/#{realm}/protocol/openid-connect/userinfo"
+    end
   end
 end

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -13,5 +13,11 @@ module KeycloakOauth
       @client_secret = client_secret
       @callback_module = callback_module
     end
+
+    def get_user_information(access_token:)
+      service = KeycloakOauth::UserInfoRetrievalService.new(access_token: access_token)
+      service.retrieve
+      service.user_information
+    end
   end
 end

--- a/lib/keycloak_oauth/endpoints.rb
+++ b/lib/keycloak_oauth/endpoints.rb
@@ -1,0 +1,18 @@
+module KeycloakOauth
+  module Endpoints
+    DEFAULT_RESPONSE_TYPE = 'code'.freeze
+
+    def authorization_endpoint(options: {})
+      endpoint = "#{auth_url}/realms/#{realm}/protocol/openid-connect/auth?client_id=#{client_id}"
+      endpoint += "&response_type=#{options[:response_type] || DEFAULT_RESPONSE_TYPE}"
+    end
+
+    def authentication_endpoint
+      "#{auth_url}/realms/#{realm}/protocol/openid-connect/token"
+    end
+
+    def user_info_endpoint
+      "#{auth_url}/realms/#{realm}/protocol/openid-connect/userinfo"
+    end
+  end
+end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -29,4 +29,12 @@ RSpec.describe KeycloakOauth::Connection do
       expect(subject.authentication_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/token')
     end
   end
+
+  describe '#user_info_endpoint' do
+    subject { KeycloakOauth.connection }
+
+    it 'returns scoped user_info_endpoint' do
+      expect(subject.user_info_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo')
+    end
+  end
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'support/helpers/keycloak_responses'
 
 RSpec.describe KeycloakOauth::Connection do
+  include Helpers::KeycloakResponses
+
   let(:auth_url) { 'http://domain/auth' }
   let(:realm) { 'first_realm' }
   let(:client_id) { 'a_client' }
@@ -35,6 +38,25 @@ RSpec.describe KeycloakOauth::Connection do
 
     it 'returns scoped user_info_endpoint' do
       expect(subject.user_info_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo')
+    end
+  end
+
+  describe '#get_user_information' do
+    it 'retrieves user information' do
+      stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
+        to_return(body: keycloak_user_info_request_body)
+
+      expect(KeycloakOauth.connection.get_user_information(access_token: 'token')).to eq({
+        "sub" => '62647491-07ba-4961-8b9a-38e43916b4a0',
+        "email_verified" => true,
+        "name" => 'First User',
+        "groups" => ['/group_A'],
+        "preferred_username" => 'first_user',
+        "given_name" => 'First',
+        "family_name" => 'User',
+        "email" => 'first_user@example.com'
+        }
+      )
     end
   end
 end

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -7,31 +7,47 @@ RSpec.describe KeycloakOauth::CallbacksController, type: :controller do
   routes { KeycloakOauth::Engine.routes }
 
   describe "GET oauth2" do
-   context 'when the host app overwrites after_sign_in_path' do
-     it 'redirects to the specified path' do
-       stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
-         to_return(body: keycloak_tokens_request_body)
+    subject { get :oauth2 }
 
-       get :oauth2
+    context 'when the host app overwrites after_sign_in_path' do
+      it 'maps user and redirects to the specified path' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
+          to_return(body: keycloak_tokens_request_body)
+        stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
+          to_return(body: keycloak_user_info_request_body)
 
-       expect(subject).to redirect_to('/second_page')
-       expect(session['access_token']).to eq(access_token)
-       expect(session['refresh_token']).to eq(refresh_token)
-     end
-   end
+        expect(subject).to redirect_to('/second_page')
+        expect(session['access_token']).to eq(access_token)
+        expect(session['refresh_token']).to eq(refresh_token)
+        expect(session['user_email_address']).to eq('first_user@example.com')
+      end
+    end
 
-   context 'when the host app does not overwrite after_sign_in_path' do
-     subject { get :oauth2 }
+    context 'when the host app does not overwrite after_sign_in_path' do
+      it 'redirects to root path' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
+          to_return(body: keycloak_tokens_request_body)
+        stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
+          to_return(body: keycloak_user_info_request_body)
 
-     it 'redirects to root path' do
-       stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
-        to_return(body: keycloak_tokens_request_body)
+        allow(described_class).to receive(:method_defined?).with(:after_sign_in_path).and_return(false)
+        allow(described_class).to receive(:method_defined?).with(:map_authenticatable).and_return(true)
 
-       allow(described_class).to receive(:method_defined?).with(:after_sign_in_path).and_return(false)
-       get :oauth2
+        expect(subject).to redirect_to('/')
+      end
+    end
 
-       expect(subject).to redirect_to('/')
-     end
-   end
+    context 'when the host app does not implement map_authenticatable' do
+      it 'redirects to root path' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
+          to_return(body: keycloak_tokens_request_body)
+        stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
+          to_return(body: keycloak_user_info_request_body)
+
+        allow(described_class).to receive(:method_defined?).with(:map_authenticatable).and_return(false)
+
+        expect{ subject }.to raise_error(NotImplementedError)
+      end
+    end
   end
 end

--- a/spec/services/user_info_retrieval_service_spec.rb
+++ b/spec/services/user_info_retrieval_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::UserInfoRetrievalService do
+  include Helpers::KeycloakResponses
+
+  describe '#retrieve' do
+    subject { KeycloakOauth::UserInfoRetrievalService.new(access_token: access_token) }
+
+    context 'when the user information can be retrieved from Keycloak' do
+      it 'retrieves authentication information and stores it in session' do
+        stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
+          to_return(body: keycloak_user_info_request_body)
+
+        service = subject
+        service.retrieve
+
+        expect(service.user_information).to eq({
+          "sub" => '62647491-07ba-4961-8b9a-38e43916b4a0',
+          "email_verified" => true,
+          "name" => 'First User',
+          "groups" => ['/group_A'],
+          "preferred_username" => 'first_user',
+          "given_name" => 'First',
+          "family_name" => 'User',
+          "email" => 'first_user@example.com'
+          }
+        )
+      end
+    end
+
+    context 'when the access token is invalid' do
+      let(:access_token) { 'some_token' }
+
+      it 'raises an error' do
+        stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
+          to_return(status: [401], body: keycloak_invalid_token_request_error_body)
+
+        expect { subject.retrieve }.to raise_error(KeycloakOauth::UserInfoRetrievalError)
+      end
+    end
+  end
+end

--- a/spec/support/helpers/keycloak_responses.rb
+++ b/spec/support/helpers/keycloak_responses.rb
@@ -19,8 +19,19 @@ module Helpers
       "tYTU0NS1kOWQzMzAzNjEzMWEifQ.eyJqdGkiOiJmNGFkODcyZC1mZTRlLTQ1ZGMtOWFjOC0yODg1OW"
     end
 
+    def keycloak_user_info_request_body
+      "{\"sub\":\"62647491-07ba-4961-8b9a-38e43916b4a0\",\"email_verified\":true" \
+      ",\"name\":\"First User\",\"groups\":[\"/group_A\"],\"preferred_username" \
+      "\":\"first_user\",\"given_name\":\"First\",\"family_name\":\"User\",\"" \
+      "email\":\"first_user@example.com\"}"
+    end
+
     def keycloak_invalid_code_request_error_body
       "{\"error\":\"invalid_grant\",\"error_description\":\"Code not valid\"}"
+    end
+
+    def keycloak_invalid_token_request_error_body
+      "{\"error\":\"invalid_token\",\"error_description\":\"Token invalid: Failed to parse JWT\"}"
     end
   end
 end

--- a/test/dummy/app/controllers/concerns/keycloak_oauth_callbacks.rb
+++ b/test/dummy/app/controllers/concerns/keycloak_oauth_callbacks.rb
@@ -10,8 +10,7 @@ module KeycloakOauthCallbacks
   end
 
   def map_authenticatable(_request)
-    service = KeycloakOauth::UserInfoRetrievalService.new(access_token: session[:access_token])
-    service.retrieve
-    session[:user_email_address] = service.user_information['email']
+    user_info = KeycloakOauth.connection.get_user_information(access_token: session[:access_token])
+    session[:user_email_address] = user_info['email']
   end
 end

--- a/test/dummy/app/controllers/concerns/keycloak_oauth_callbacks.rb
+++ b/test/dummy/app/controllers/concerns/keycloak_oauth_callbacks.rb
@@ -8,4 +8,10 @@ module KeycloakOauthCallbacks
   def after_sign_in_path(request)
     request.params[:show_first_page].present? ? first_page_path : second_page_path
   end
+
+  def map_authenticatable(_request)
+    service = KeycloakOauth::UserInfoRetrievalService.new(access_token: session[:access_token])
+    service.retrieve
+    session[:user_email_address] = service.user_information['email']
+  end
 end


### PR DESCRIPTION
This PR adds support for accessing the following Keycloak endpoint:
`http://domain/auth/realms/a_realm/protocol/openid-connect/userinfo`.

We also add a mechanism for allowing the host app to implement its own logic for mapping a Keycloak user with a Rails user. 