### PR TITLE
Add support for logging out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,8 @@ group :test do
 end
 
 group :development, :test do
+  # Needed for the dummy app.
   gem 'activerecord-session_store'
+  gem 'uglifier', '>= 1.3.0'
+  gem 'turbolinks', '~> 5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.9.0)
+    execjs (2.7.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -155,8 +156,13 @@ GEM
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
+    turbolinks (5.2.1)
+      turbolinks-source (~> 5.2)
+    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    uglifier (4.2.0)
+      execjs (>= 0.3.0, < 3)
     webmock (3.9.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -174,6 +180,8 @@ DEPENDENCIES
   keycloak_oauth!
   rspec-rails
   sqlite3
+  turbolinks (~> 5)
+  uglifier (>= 1.3.0)
   webmock
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ def map_authenticatable(_request)
 end
 ```
 
+**Logging out**
+In order to log out, you can use the following API call:
+`KeycloakOauth.connection.logout(session: session)`
+
+Note that you need to pass in the session, as the gem needs to remove the Keycloak tokens from there.
+
+e.g.
+```ruby
+class SessionsController < ApplicationController
+  def destroy
+    KeycloakOauth.connection.logout(session: session)
+    redirect_to new_session_path
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -7,13 +7,14 @@ module KeycloakOauth
     DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
     AUTHORIZATION_HEADER = 'Authorization'.freeze
 
-    def initialize(access_token:)
+    def initialize(access_token:, refresh_token:)
       @access_token = access_token
+      @refresh_token = refresh_token
     end
 
     private
 
-    attr_accessor :access_token
+    attr_accessor :access_token, :refresh_token
 
     def parsed_response(http_response)
       response_hash = JSON.parse(http_response.body)

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -4,6 +4,7 @@ module KeycloakOauth
   class AuthorizableError < StandardError; end
 
   class AuthorizableService
+    HTTP_SUCCESS_CODES = [Net::HTTPOK, Net::HTTPNoContent]
     DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
     AUTHORIZATION_HEADER = 'Authorization'.freeze
 
@@ -17,14 +18,14 @@ module KeycloakOauth
     attr_accessor :access_token, :refresh_token
 
     def parsed_response(http_response)
-      response_hash = JSON.parse(http_response.body)
+      response = http_response.body.nil? ? http_response.body : JSON.parse(http_response.body)
 
-      return response_hash if http_response.code_type == Net::HTTPOK
+      return response if HTTP_SUCCESS_CODES.include?(http_response.code_type)
 
       # TODO: For now, we assume that the access token is always valid.
       # We do not yet handle the case where a refresh token is passed in and
       # used if the access token has expired.
-      raise KeycloakOauth::AuthorizableError.new(response_hash)
+      raise KeycloakOauth::AuthorizableError.new(response)
     end
   end
 end

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -18,7 +18,7 @@ module KeycloakOauth
     attr_accessor :access_token, :refresh_token
 
     def parsed_response(http_response)
-      response = http_response.body.nil? ? http_response.body : JSON.parse(http_response.body)
+      response = http_response.body.present? ? JSON.parse(http_response.body) : http_response.body
 
       return response if HTTP_SUCCESS_CODES.include?(http_response.code_type)
 

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -1,0 +1,29 @@
+require 'net/http'
+
+module KeycloakOauth
+  class AuthorizableError < StandardError; end
+
+  class AuthorizableService
+    DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
+    AUTHORIZATION_HEADER = 'Authorization'.freeze
+
+    def initialize(access_token:)
+      @access_token = access_token
+    end
+
+    private
+
+    attr_accessor :access_token
+
+    def parsed_response(http_response)
+      response_hash = JSON.parse(http_response.body)
+
+      return response_hash if http_response.code_type == Net::HTTPOK
+
+      # TODO: For now, we assume that the access token is always valid.
+      # We do not yet handle the case where a refresh token is passed in and
+      # used if the access token has expired.
+      raise KeycloakOauth::AuthorizableError.new(response_hash)
+    end
+  end
+end

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -8,14 +8,7 @@ module KeycloakOauth
     DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
     AUTHORIZATION_HEADER = 'Authorization'.freeze
 
-    def initialize(access_token:, refresh_token:)
-      @access_token = access_token
-      @refresh_token = refresh_token
-    end
-
     private
-
-    attr_accessor :access_token, :refresh_token
 
     def parsed_response(http_response)
       response = http_response.body.present? ? JSON.parse(http_response.body) : http_response.body

--- a/app/services/keycloak_oauth/logout_service.rb
+++ b/app/services/keycloak_oauth/logout_service.rb
@@ -1,0 +1,21 @@
+require 'net/http'
+
+module KeycloakOauth
+  class LogoutService < KeycloakOauth::AuthorizableService
+    def logout
+      parsed_response(post_logout)
+    end
+
+    private
+
+    def post_logout
+      uri = URI.parse(KeycloakOauth.connection.logout_endpoint)
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        request = Net::HTTP::Post.new(uri)
+        request.set_content_type(DEFAULT_CONTENT_TYPE)
+        request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
+        http.request(request)
+      end
+    end
+  end
+end

--- a/app/services/keycloak_oauth/logout_service.rb
+++ b/app/services/keycloak_oauth/logout_service.rb
@@ -13,9 +13,18 @@ module KeycloakOauth
       Net::HTTP.start(uri.host, uri.port) do |http|
         request = Net::HTTP::Post.new(uri)
         request.set_content_type(DEFAULT_CONTENT_TYPE)
+        request.set_form_data(logout_request_params)
         request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
         http.request(request)
       end
+    end
+
+    def logout_request_params
+      {
+        client_id: KeycloakOauth.connection.client_id,
+        client_secret: KeycloakOauth.connection.client_secret,
+        refresh_token: refresh_token
+      }
     end
   end
 end

--- a/app/services/keycloak_oauth/logout_service.rb
+++ b/app/services/keycloak_oauth/logout_service.rb
@@ -2,11 +2,17 @@ require 'net/http'
 
 module KeycloakOauth
   class LogoutService < KeycloakOauth::AuthorizableService
+    def initialize(session)
+      @session = session
+    end
+
     def logout
       parsed_response(post_logout)
     end
 
     private
+
+    attr_accessor :session
 
     def post_logout
       uri = URI.parse(KeycloakOauth.connection.logout_endpoint)
@@ -25,6 +31,14 @@ module KeycloakOauth
         client_secret: KeycloakOauth.connection.client_secret,
         refresh_token: refresh_token
       }
+    end
+
+    def access_token
+      session[:access_token]
+    end
+
+    def refresh_token
+      session[:refresh_token]
     end
   end
 end

--- a/app/services/keycloak_oauth/user_info_retrieval_service.rb
+++ b/app/services/keycloak_oauth/user_info_retrieval_service.rb
@@ -4,11 +4,18 @@ module KeycloakOauth
   class UserInfoRetrievalService < KeycloakOauth::AuthorizableService
     attr_reader :user_information
 
+    def initialize(access_token:, refresh_token:)
+      @access_token = access_token
+      @refresh_token = refresh_token
+    end
+
     def retrieve
       @user_information = parsed_response(get_user)
     end
 
     private
+
+    attr_accessor :access_token, :refresh_token
 
     def get_user
       uri = URI.parse(KeycloakOauth.connection.user_info_endpoint)

--- a/app/services/keycloak_oauth/user_info_retrieval_service.rb
+++ b/app/services/keycloak_oauth/user_info_retrieval_service.rb
@@ -1,45 +1,23 @@
 require 'net/http'
 
 module KeycloakOauth
-  class UserInfoRetrievalError < StandardError; end
-
-  class UserInfoRetrievalService
-    AUTHORIZATION_HEADER = 'Authorization'.freeze
-    CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
-
+  class UserInfoRetrievalService < KeycloakOauth::AuthorizableService
     attr_reader :user_information
 
-    def initialize(access_token:)
-      @access_token = access_token
-    end
-
     def retrieve
-      @user_information = parsed_user_information(get_user)
+      @user_information = parsed_response(get_user)
     end
 
     private
-
-    attr_accessor :access_token
 
     def get_user
       uri = URI.parse(KeycloakOauth.connection.user_info_endpoint)
       Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
         request = Net::HTTP::Get.new(uri)
-        request.set_content_type(CONTENT_TYPE)
+        request.set_content_type(DEFAULT_CONTENT_TYPE)
         request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
         http.request(request)
       end
-    end
-
-    def parsed_user_information(http_response)
-      response_hash = JSON.parse(http_response.body)
-
-      return response_hash if http_response.code_type == Net::HTTPOK
-
-      # TODO: For now, we assume that the access token is always valid.
-      # We do not yet handle the case where a refresh token is passed in and
-      # used if the access token has expired.
-      raise KeycloakOauth::UserInfoRetrievalError.new(response_hash)
     end
   end
 end

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -22,5 +22,13 @@ module KeycloakOauth
       service.retrieve
       service.user_information
     end
+
+    def logout(access_token:, refresh_token:)
+      service = KeycloakOauth::LogoutService.new(
+        access_token: access_token,
+        refresh_token: refresh_token
+      )
+      service.logout
+    end
   end
 end

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -23,11 +23,8 @@ module KeycloakOauth
       service.user_information
     end
 
-    def logout(access_token:, refresh_token:)
-      service = KeycloakOauth::LogoutService.new(
-        access_token: access_token,
-        refresh_token: refresh_token
-      )
+    def logout(session:)
+      service = KeycloakOauth::LogoutService.new(session)
       service.logout
     end
   end

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -14,8 +14,11 @@ module KeycloakOauth
       @callback_module = callback_module
     end
 
-    def get_user_information(access_token:)
-      service = KeycloakOauth::UserInfoRetrievalService.new(access_token: access_token)
+    def get_user_information(access_token:, refresh_token:)
+      service = KeycloakOauth::UserInfoRetrievalService.new(
+        access_token: access_token,
+        refresh_token: refresh_token
+      )
       service.retrieve
       service.user_information
     end

--- a/lib/keycloak_oauth/endpoints.rb
+++ b/lib/keycloak_oauth/endpoints.rb
@@ -16,5 +16,9 @@ module KeycloakOauth
     def user_info_endpoint
       "#{auth_url}/realms/#{realm}/protocol/openid-connect/userinfo"
     end
+
+    def logout_endpoint
+      "#{auth_url}/realms/#{realm}/protocol/openid-connect/logout"
+    end
   end
 end

--- a/lib/keycloak_oauth/version.rb
+++ b/lib/keycloak_oauth/version.rb
@@ -1,3 +1,3 @@
 module KeycloakOauth
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -49,20 +49,19 @@ RSpec.describe KeycloakOauth::Connection do
     end
   end
 
-  describe '#logout_endpoint' do
-    subject { KeycloakOauth.connection }
-
-    it 'returns scoped logout_endpoint' do
-      expect(subject.logout_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/logout')
-    end
-  end
-
   describe '#get_user_information' do
+    subject do
+      KeycloakOauth.connection.get_user_information(
+        access_token: 'access_token',
+        refresh_token: 'refresh_token'
+      )
+    end
+
     it 'retrieves user information' do
       stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
         to_return(body: keycloak_user_info_request_body)
 
-      expect(KeycloakOauth.connection.get_user_information(access_token: 'token')).to eq({
+      expect(subject).to eq({
         "sub" => '62647491-07ba-4961-8b9a-38e43916b4a0',
         "email_verified" => true,
         "name" => 'First User',

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe KeycloakOauth::Connection do
     end
   end
 
+  describe '#logout_endpoint' do
+    subject { KeycloakOauth.connection }
+
+    it 'returns scoped logout_endpoint' do
+      expect(subject.logout_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/logout')
+    end
+  end
+
   describe '#get_user_information' do
     it 'retrieves user information' do
       stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -9,46 +9,6 @@ RSpec.describe KeycloakOauth::Connection do
   let(:client_id) { 'a_client' }
   let(:client_secret) { 'a_secret' }
 
-  describe '#authorization_endpoint' do
-    subject { KeycloakOauth.connection }
-
-    it 'returns scoped authorization_endpoint' do
-      expect(subject.authorization_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=code')
-    end
-
-    context 'when response_type is passed in' do
-      it 'returns scoped authorization_endpoint with custom response_type' do
-        endpoint = subject.authorization_endpoint(options: { response_type: 'token' })
-
-        expect(endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=token')
-      end
-    end
-
-    context 'when redirect_uri is passed in' do
-      it 'returns scoped authorization_endpoint with custom redirect_uri' do
-        endpoint = subject.authorization_endpoint(options: { redirect_uri: 'http://example.com/oauth2' })
-
-        expect(endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=code&redirect_uri=http://example.com/oauth2')
-      end
-    end
-  end
-
-  describe '#authentication_endpoint' do
-    subject { KeycloakOauth.connection }
-
-    it 'returns scoped authorization_endpoint' do
-      expect(subject.authentication_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/token')
-    end
-  end
-
-  describe '#user_info_endpoint' do
-    subject { KeycloakOauth.connection }
-
-    it 'returns scoped user_info_endpoint' do
-      expect(subject.user_info_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo')
-    end
-  end
-
   describe '#get_user_information' do
     subject do
       KeycloakOauth.connection.get_user_information(

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -34,4 +34,20 @@ RSpec.describe KeycloakOauth::Connection do
       )
     end
   end
+
+  describe '#logout' do
+    subject do
+      KeycloakOauth.connection.logout(
+        access_token: 'access_token',
+        refresh_token: 'refresh_token'
+      )
+    end
+
+    it 'logs out' do
+      stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').
+        to_return(status: [204], body: nil)
+
+      expect(subject).to be_nil
+    end
+  end
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -36,12 +36,9 @@ RSpec.describe KeycloakOauth::Connection do
   end
 
   describe '#logout' do
-    subject do
-      KeycloakOauth.connection.logout(
-        access_token: 'access_token',
-        refresh_token: 'refresh_token'
-      )
-    end
+    let(:session) { OpenStruct.new(access_token: 'token_A', refresh_token: 'token_B') }
+
+    subject { KeycloakOauth.connection.logout(session: session) }
 
     it 'logs out' do
       stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').

--- a/spec/endpoints_spec.rb
+++ b/spec/endpoints_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe KeycloakOauth::Endpoints do
+  let(:auth_url) { 'http://domain/auth' }
+  let(:realm) { 'first_realm' }
+  let(:client_id) { 'a_client' }
+  let(:client_secret) { 'a_secret' }
+
+  subject { KeycloakOauth.connection }
+
+  describe '#authorization_endpoint' do
+    subject { KeycloakOauth.connection }
+
+    it 'returns scoped authorization_endpoint' do
+      expect(subject.authorization_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=code')
+    end
+
+    context 'when response_type is passed in' do
+      it 'returns scoped authorization_endpoint with custom response_type' do
+        endpoint = subject.authorization_endpoint(options: { response_type: 'token' })
+
+        expect(endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=token')
+      end
+    end
+
+    context 'when redirect_uri is passed in' do
+      it 'returns scoped authorization_endpoint with custom redirect_uri' do
+        endpoint = subject.authorization_endpoint(options: { redirect_uri: 'http://example.com/oauth2' })
+
+        expect(endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=code&redirect_uri=http://example.com/oauth2')
+      end
+    end
+  end
+
+  describe '#authentication_endpoint' do
+    subject { KeycloakOauth.connection }
+
+    it 'returns scoped authorization_endpoint' do
+      expect(subject.authentication_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/token')
+    end
+  end
+
+  describe '#user_info_endpoint' do
+    subject { KeycloakOauth.connection }
+
+    it 'returns scoped user_info_endpoint' do
+      expect(subject.user_info_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo')
+    end
+  end
+
+  describe '#logout_endpoint' do
+    it 'returns scoped user_info_endpoint' do
+      expect(subject.logout_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/logout')
+    end
+  end
+end

--- a/spec/services/logout_service_spec.rb
+++ b/spec/services/logout_service_spec.rb
@@ -5,12 +5,9 @@ RSpec.describe KeycloakOauth::LogoutService do
   include Helpers::KeycloakResponses
 
   describe '#logout' do
-    subject do
-      KeycloakOauth::LogoutService.new(
-        access_token: access_token,
-        refresh_token: refresh_token
-      )
-    end
+    let(:session) { OpenStruct.new(access_token: 'token_A', refresh_token: 'token_B') }
+
+    subject { KeycloakOauth::LogoutService.new(session) }
 
     it 'logs out from Keycloak' do
       stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').
@@ -23,7 +20,7 @@ RSpec.describe KeycloakOauth::LogoutService do
     end
 
     context 'when the access token is invalid' do
-      let(:access_token) { 'some_token' }
+      let(:session) { OpenStruct.new(access_token: 'invalid') }
 
       it 'raises an error' do
         stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').

--- a/spec/services/logout_service_spec.rb
+++ b/spec/services/logout_service_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe KeycloakOauth::LogoutService do
   include Helpers::KeycloakResponses
 
   describe '#logout' do
-    subject { KeycloakOauth::LogoutService.new(access_token: access_token) }
+    subject do
+      KeycloakOauth::LogoutService.new(
+        access_token: access_token,
+        refresh_token: refresh_token
+      )
+    end
 
     context 'when the access token is invalid' do
       let(:access_token) { 'some_token' }

--- a/spec/services/logout_service_spec.rb
+++ b/spec/services/logout_service_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe KeycloakOauth::LogoutService do
       )
     end
 
+    it 'logs out from Keycloak' do
+      stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').
+        to_return(status: [204], body: nil) # Keycloak replies with an empty body.
+
+      service = subject
+      service.logout
+
+      expect(service.logout).to be_nil
+    end
+
     context 'when the access token is invalid' do
       let(:access_token) { 'some_token' }
 

--- a/spec/services/logout_service_spec.rb
+++ b/spec/services/logout_service_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::LogoutService do
+  include Helpers::KeycloakResponses
+
+  describe '#logout' do
+    subject { KeycloakOauth::LogoutService.new(access_token: access_token) }
+
+    context 'when the access token is invalid' do
+      let(:access_token) { 'some_token' }
+
+      it 'raises an error' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').
+          to_return(status: [401], body: keycloak_invalid_token_request_error_body)
+
+        expect { subject.logout }.to raise_error(KeycloakOauth::AuthorizableError)
+      end
+    end
+  end
+end

--- a/spec/services/user_info_retrieval_service_spec.rb
+++ b/spec/services/user_info_retrieval_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe KeycloakOauth::UserInfoRetrievalService do
         stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
           to_return(status: [401], body: keycloak_invalid_token_request_error_body)
 
-        expect { subject.retrieve }.to raise_error(KeycloakOauth::UserInfoRetrievalError)
+        expect { subject.retrieve }.to raise_error(KeycloakOauth::AuthorizableError)
       end
     end
   end

--- a/spec/services/user_info_retrieval_service_spec.rb
+++ b/spec/services/user_info_retrieval_service_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe KeycloakOauth::UserInfoRetrievalService do
   include Helpers::KeycloakResponses
 
   describe '#retrieve' do
-    subject { KeycloakOauth::UserInfoRetrievalService.new(access_token: access_token) }
+    subject do
+      KeycloakOauth::UserInfoRetrievalService.new(
+        access_token: access_token, refresh_token: refresh_token
+      )
+    end
 
     context 'when the user information can be retrieved from Keycloak' do
       it 'retrieves authentication information and stores it in session' do

--- a/test/dummy/app/assets/javascripts/application.js
+++ b/test/dummy/app/assets/javascripts/application.js
@@ -1,0 +1,1 @@
+//= require rails-ujs

--- a/test/dummy/app/controllers/concerns/keycloak_oauth_callbacks.rb
+++ b/test/dummy/app/controllers/concerns/keycloak_oauth_callbacks.rb
@@ -10,7 +10,10 @@ module KeycloakOauthCallbacks
   end
 
   def map_authenticatable(_request)
-    user_info = KeycloakOauth.connection.get_user_information(access_token: session[:access_token])
+    user_info = KeycloakOauth.connection.get_user_information(
+      access_token: session[:access_token],
+      refresh_token: session[:refresh_token]
+    )
     session[:user_email_address] = user_info['email']
   end
 end

--- a/test/dummy/app/controllers/sessions_controller.rb
+++ b/test/dummy/app/controllers/sessions_controller.rb
@@ -1,0 +1,6 @@
+class SessionsController < ApplicationController
+  def destroy
+    KeycloakOauth.connection.logout(session: session)
+    redirect_to first_page_path
+  end
+end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title>Dummy</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= javascript_include_tag 'application' %>
 
   </head>
 

--- a/test/dummy/app/views/pages/second_page.html.erb
+++ b/test/dummy/app/views/pages/second_page.html.erb
@@ -1,1 +1,3 @@
 I am the second page.
+
+<%= link_to 'Logout from Keycloak', session_path, method: :delete %>

--- a/test/dummy/config/initializers/assets.rb
+++ b/test/dummy/config/initializers/assets.rb
@@ -9,4 +9,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( application.js )

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   get 'first_page', to: 'pages#first_page'
   get 'second_page', to: 'pages#second_page'
 
+  resource :session, only: [:destroy]
+
   root to: 'pages#second_page'
 end


### PR DESCRIPTION
The following changes were made:
- Changing assets to load JS libraries. We need these for testing purposes, as we added a button which has a data attribute (see the `Logout` button in the dummy app).
- Added a new service for logging out, `KeycloakOauth::LogoutService`. As this shares some functionality with the `KeycloakOauth::UserInfoRetrievalService`, I've added a superclass with the shared functionality for these two.
- Moving endpoint related tests to `specs/endpoints_test.rb`
- Adding an example usage of the logout functionality in the dummy app.