### PR TITLE
Use context from host app in controllers

### DIFF
--- a/app/controllers/keycloak_oauth/application_controller.rb
+++ b/app/controllers/keycloak_oauth/application_controller.rb
@@ -1,5 +1,0 @@
-module KeycloakOauth
-  class ApplicationController < ActionController::Base
-    protect_from_forgery with: :exception
-  end
-end

--- a/app/controllers/keycloak_oauth/callbacks_controller.rb
+++ b/app/controllers/keycloak_oauth/callbacks_controller.rb
@@ -1,5 +1,5 @@
 module KeycloakOauth
-  class CallbacksController < ApplicationController
+  class CallbacksController < ::ApplicationController
     if KeycloakOauth.connection.callback_module.present?
       include KeycloakOauth.connection.callback_module
     end


### PR DESCRIPTION
It looks like we need to allow the `CallbacksController` to inherit from the main application's `ApplicationController`. That is because there could be additional logic in the host app (e.g. `before_action` calls) which might need to be skipped in the case of actions coming from `CallbacksController`.

e.g. 
Host app defines a `before_action` to set the user which we wouldn't want to apply to the `oauth2` callback (as then the filter would prevent the controller action from being performed). 
In this case, the host app could override the callbacks controller like this:
```ruby
class CallbackOverridesController < KeycloakOauth::CallbacksController
  skip_before_action :set_user
end
```

Of course, some applications do not have an `ApplicationController`. One option around this is to check if one exists and inherit from `ActionController::Base` if it doesn't. But I propose to handle this at a later stage. 