### PR TITLE
Passing in redirect_uri in requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ e.g.
 
 Once authentication is performed, the access and refresh tokens are stored in the session and can be used in your app as wished.
 
+***Customising redirect URIs***
+There are situations where you would want to customise the oauth2 route (e.g. to use a localised version of the callback URL).
+In this case, you can do the following:
+- add a controller to your app: e.g. `CallbackOverrides`
+- add the following to your routes.rb file: `get 'oauth2', to: 'callback_overrides#oauth2'`
+- add whatever logic you need in the controller, e.g. a `skip_before_action`; it can also be blank
+- add redirect URI to the authorization link:
+e.g.
+`<%= link_to 'Login with Keycloak', KeycloakOauth.connection.authorization_endpoint(options: {redirect_uri: 'http://myapp.com/en/oauth2'}) %>`
+
+Note: Make sure you update your routes in this case, to ensure that
+
 **Keycloak callback URL**
 Keycloak needs a callback URL to send the authorization code to once a user logs in.
 By default, once authentication is performed, we redirect to the `/` path (i.e. whatever the root path is set to in the host app).

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ In this case, you can do the following:
 e.g.
 `<%= link_to 'Login with Keycloak', KeycloakOauth.connection.authorization_endpoint(options: {redirect_uri: 'http://myapp.com/en/oauth2'}) %>`
 
-Note: Make sure you update your routes in this case, to ensure that
-
 **Keycloak callback URL**
 Keycloak needs a callback URL to send the authorization code to once a user logs in.
 By default, once authentication is performed, we redirect to the `/` path (i.e. whatever the root path is set to in the host app).

--- a/app/services/keycloak_oauth/authentication_service.rb
+++ b/app/services/keycloak_oauth/authentication_service.rb
@@ -9,11 +9,12 @@ module KeycloakOauth
     ACCESS_TOKEN_KEY = 'access_token'.freeze
     REFRESH_TOKEN_KEY = 'refresh_token'.freeze
 
-    attr_reader :code, :session
+    attr_reader :session
 
-    def initialize(authentication_params:, session:)
+    def initialize(authentication_params:, session:, redirect_uri:)
       @code = authentication_params[:code]
       @session = session
+      @redirect_uri = redirect_uri
     end
 
     def authenticate
@@ -21,6 +22,8 @@ module KeycloakOauth
     end
 
     private
+
+    attr_reader :code, :redirect_uri
 
     def get_tokens
       uri = URI.parse(KeycloakOauth.connection.authentication_endpoint)
@@ -37,7 +40,8 @@ module KeycloakOauth
         client_id: KeycloakOauth.connection.client_id,
         client_secret: KeycloakOauth.connection.client_secret,
         grant_type: GRANT_TYPE,
-        code: code
+        code: code,
+        redirect_uri: redirect_uri
       }
     end
 

--- a/lib/keycloak_oauth/endpoints.rb
+++ b/lib/keycloak_oauth/endpoints.rb
@@ -5,6 +5,8 @@ module KeycloakOauth
     def authorization_endpoint(options: {})
       endpoint = "#{auth_url}/realms/#{realm}/protocol/openid-connect/auth?client_id=#{client_id}"
       endpoint += "&response_type=#{options[:response_type] || DEFAULT_RESPONSE_TYPE}"
+      endpoint += "&redirect_uri=#{options[:redirect_uri]}" if options[:redirect_uri].present?
+      endpoint
     end
 
     def authentication_endpoint

--- a/lib/keycloak_oauth/version.rb
+++ b/lib/keycloak_oauth/version.rb
@@ -1,3 +1,3 @@
 module KeycloakOauth
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe KeycloakOauth::Connection do
         expect(endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=token')
       end
     end
+
+    context 'when redirect_uri is passed in' do
+      it 'returns scoped authorization_endpoint with custom redirect_uri' do
+        endpoint = subject.authorization_endpoint(options: { redirect_uri: 'http://example.com/oauth2' })
+
+        expect(endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/auth?client_id=a_client&response_type=code&redirect_uri=http://example.com/oauth2')
+      end
+    end
   end
 
   describe '#authentication_endpoint' do

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe KeycloakOauth::AuthenticationService do
     subject do
       KeycloakOauth::AuthenticationService.new(
         authentication_params: dummy_authentication_params,
-        session: session
+        session: session,
+        redirect_uri: 'http://example.com/oauth2'
       )
     end
 


### PR DESCRIPTION
This allows host applications to override the `oauth2` route (for example, to allow a localised `oauth2` route which would then ensure that the language of the user logging in from the host app is not lost after Keycloak replies). 

The host app can then do something like this:
- add the following URL to the login btn: `KeycloakOauth.connection.authorization_endpoint(options: { redirect_uri: localised_oauth2_url })` 

If using a redirect_uri on the `auth` endpoint, Keycloak will also require a redirect_uri parameter to be set when making the request to the `token` endpoint. If this is not done, the API replies with an error `{   "error_description": "incorrect redirect_uri",   "error":"invalid_grant” } `.

Therefore, we need to pass the `redirect_uri` as well. If the host app does not override the oauth2 route, we are defaulting the redirect_uri to the engine's oauth2 route.