### PR TITLE
Enable SSL for Keycloak requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keycloak_oauth (0.1.3)
+    keycloak_oauth (0.1.5)
       rails (~> 6.0.3, >= 6.0.3.2)
 
 GEM

--- a/app/services/keycloak_oauth/authentication_service.rb
+++ b/app/services/keycloak_oauth/authentication_service.rb
@@ -27,7 +27,7 @@ module KeycloakOauth
 
     def get_tokens
       uri = URI.parse(KeycloakOauth.connection.authentication_endpoint)
-      Net::HTTP.start(uri.host, uri.port) do |http|
+      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
         request = Net::HTTP::Post.new(uri)
         request.set_content_type(CONTENT_TYPE)
         request.set_form_data(token_request_params)

--- a/app/services/keycloak_oauth/user_info_retrieval_service.rb
+++ b/app/services/keycloak_oauth/user_info_retrieval_service.rb
@@ -23,7 +23,7 @@ module KeycloakOauth
 
     def get_user
       uri = URI.parse(KeycloakOauth.connection.user_info_endpoint)
-      Net::HTTP.start(uri.host, uri.port) do |http|
+      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
         request = Net::HTTP::Get.new(uri)
         request.set_content_type(CONTENT_TYPE)
         request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"

--- a/lib/keycloak_oauth/version.rb
+++ b/lib/keycloak_oauth/version.rb
@@ -1,3 +1,3 @@
 module KeycloakOauth
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Ruby's Net::HTTP does not automatically send HTTPS requests based on
the uri. Instead, we need to specify `use_ssl` on SSL endpoints.