### PR TITLE
Add pipeline which automates testing and releasing the gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Tag on Github and Release to RubyGems
+on: [workflow_dispatch]
+
+jobs:
+  release:
+    name: Release to RubyGems
+    runs-on: ubuntu-latest
+    # Ideally, we would require successful tests before
+    # allowing to publish. Because the tests need to be
+    # in a separate workflow file, we can't reference it
+    # here.
+    # needs: test
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Tag on Github
+        run: |
+          # Todo: maybe there's a better way to get the version
+          VERSION=$(echo "require './lib/keycloak_oauth/version.rb'; puts KeycloakOauth::VERSION" | ruby)
+          echo "v$VERSION"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           ruby-version: 2.7
       - name: Tag on Github
         run: |
-          VERSION=$(echo "puts Gem::Specification::load('keycloak_oauth.gemspec').version" | ruby)
+          VERSION=$(ruby -e "puts Gem::Specification::load('keycloak_oauth.gemspec').version")
           echo "v$VERSION"
           git tag "v$VERSION"
           git push origin "v$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ jobs:
           ruby-version: 2.7
       - name: Tag on Github
         run: |
-          # Todo: maybe there's a better way to get the version
-          VERSION=$(echo "require './lib/keycloak_oauth/version.rb'; puts KeycloakOauth::VERSION" | ruby)
+          VERSION=$(echo "puts Gem::Specification::load('keycloak_oauth.gemspec').version" | ruby)
           echo "v$VERSION"
           git tag "v$VERSION"
           git push origin "v$VERSION"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: bundle-${{ matrix.ruby }}-${{ hashFiles('**/*.gemspec') }}
+          key: bundle-${{ matrix.ruby }}-${{ hashFiles('**/*.gemspec', '**/Gemfile.lock') }}
           restore-keys: bundle-${{ matrix.ruby }}
       - run: bundle config set path 'vendor/bundle'
       - run: bundle install --jobs 2 --retry 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        ruby: [2.5, 2.6, 2.7]
+    runs-on: ubuntu-latest
+    name: Test on Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: bundle-${{ matrix.ruby }}-${{ hashFiles('**/*.gemspec') }}
+          restore-keys: bundle-${{ matrix.ruby }}
+      - run: bundle install --jobs 4 --retry 3 --path vendor/bundle
+      - run: bundle exec rake spec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,5 +23,6 @@ jobs:
           path: vendor/bundle
           key: bundle-${{ matrix.ruby }}-${{ hashFiles('**/*.gemspec') }}
           restore-keys: bundle-${{ matrix.ruby }}
-      - run: bundle install --jobs 4 --retry 3 --path vendor/bundle
+      - run: bundle config set path 'vendor/bundle'
+      - run: bundle install --jobs 4 --retry 3
       - run: bundle exec rake spec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,5 +24,5 @@ jobs:
           key: bundle-${{ matrix.ruby }}-${{ hashFiles('**/*.gemspec') }}
           restore-keys: bundle-${{ matrix.ruby }}
       - run: bundle config set path 'vendor/bundle'
-      - run: bundle install --jobs 4 --retry 3
+      - run: bundle install --jobs 2 --retry 3
       - run: bundle exec rake spec

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ test/dummy/tmp/
 # rspec failure tracking
 .rspec_status
 .byebug_history
+
+/vendor/


### PR DESCRIPTION
We want to automatically test, build and push the gem to RubyGems when merging changes to the main branch. This PR prepares the Github Actions workflow to accomplish this.

The pipeline currently has two workflow files, the `tests.yml` which
* runs on pull requests to the main branch and when pushing / merging to the main branch itself
* has a matrix test strategy which tests on Ruby 2.5, 2.6 and 2.7
* runs `rake spec` to run the gem tests

and the `release.yml` which
* runs upon being manually triggered
* adds a tag to Github with the current gem version (in `lib/keycloak_oauth/version.rb`) and
* publishes the gem to RubyGems

Additional notes:
* Unfortunately it's currently possible to run the release workflow without the tests having passed. I did not find a way to require this (because the release workflow must be defined in a separate file).
* The manual action trigger does appear in Github Actions once it's merged to the main branch.
* We can't use `rake release` because it requires some Github configuration like user name, email etc. to be set up. This is why we separately tag to Github and then use `gem build` and `gem push` as guided in the Github Actions starter template (https://github.com/actions/starter-workflows/blob/d7ac62140faf23b67c29e892d4ce68342eb09609/ci/gem-push.yml#L33)