### PR TITLE
Add support for creating Keycloak users through API

### DIFF
--- a/app/controllers/keycloak_oauth/callbacks_controller.rb
+++ b/app/controllers/keycloak_oauth/callbacks_controller.rb
@@ -7,8 +7,7 @@ module KeycloakOauth
     def oauth2
       authentication_service = KeycloakOauth::AuthenticationService.new(
         authentication_params: authentication_params,
-        session: session,
-        redirect_uri: current_uri_without_params
+        session: session
       )
       authentication_service.authenticate
       map_authenticatable_if_implemented(session)
@@ -19,7 +18,7 @@ module KeycloakOauth
     private
 
     def authentication_params
-      params.permit(:code)
+      params.permit(:code).merge({ redirect_uri: current_uri_without_params })
     end
 
     def map_authenticatable_if_implemented(request)

--- a/app/services/keycloak_oauth/authentication_service.rb
+++ b/app/services/keycloak_oauth/authentication_service.rb
@@ -1,6 +1,4 @@
 module KeycloakOauth
-  class AuthenticationError < StandardError; end
-
   class AuthenticationService
     ACCESS_TOKEN_KEY = 'access_token'.freeze
     REFRESH_TOKEN_KEY = 'refresh_token'.freeze
@@ -17,20 +15,17 @@ module KeycloakOauth
         connection: KeycloakOauth.connection,
         request_params: authentication_params
       )
-      store_credentials(post_token_service.send_request)
+      post_token_service.perform
+      store_credentials(post_token_service)
     end
 
     private
 
-    def store_credentials(http_response)
-      response_hash = JSON.parse(http_response.body)
+    def store_credentials(post_token_service)
+      response_hash = post_token_service.parsed_response_body
 
-      if http_response.code_type == Net::HTTPOK
-        session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
-        session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
-      else
-        raise KeycloakOauth::AuthenticationError.new(response_hash)
-      end
+      session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
+      session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
     end
   end
 end

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -4,7 +4,7 @@ module KeycloakOauth
   class AuthorizableError < StandardError; end
 
   class AuthorizableService
-    HTTP_SUCCESS_CODES = [Net::HTTPOK, Net::HTTPNoContent]
+    HTTP_SUCCESS_CODES = [Net::HTTPOK, Net::HTTPNoContent, Net::HTTPCreated]
     DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
     AUTHORIZATION_HEADER = 'Authorization'.freeze
 

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -18,7 +18,26 @@ module KeycloakOauth
       # TODO: For now, we assume that the access token is always valid.
       # We do not yet handle the case where a refresh token is passed in and
       # used if the access token has expired.
-      raise KeycloakOauth::AuthorizableError.new(response)
+      raise KeycloakOauth::AuthorizableError.new(error_message_from(response))
+    end
+
+    def error_message_from(response)
+      # Keycloak sometimes sends back a hash containing the "errorMessage" key,
+      # other times it returns a hash containing the "error_description key" key
+      # and other times it returns an empty string. There could be more cases,
+      # but for the moment we are only handling these three.
+      case response.class.to_s
+      when 'Hash'
+        if response.has_key?('errorMessage')
+          return response['errorMessage']
+        elsif response.has_key?('error_description')
+          return response['error_description']
+        end
+      when 'String'
+        return response
+      else
+        'Unexpected Keycloak error'
+      end
     end
   end
 end

--- a/app/services/keycloak_oauth/logout_service.rb
+++ b/app/services/keycloak_oauth/logout_service.rb
@@ -6,8 +6,8 @@ module KeycloakOauth
       @session = session
     end
 
-    def logout
-      parsed_response(post_logout)
+    def send_request
+      post_logout
     end
 
     private

--- a/app/services/keycloak_oauth/post_token_service.rb
+++ b/app/services/keycloak_oauth/post_token_service.rb
@@ -1,9 +1,8 @@
 require 'net/http'
 
 module KeycloakOauth
-  class PostTokenService
+  class PostTokenService < KeycloakOauth::AuthorizableService
     DEFAULT_GRANT_TYPE = 'authorization_code'.freeze
-    CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
 
     attr_reader :request_params, :connection
 
@@ -24,7 +23,7 @@ module KeycloakOauth
       uri = URI.parse(connection.authentication_endpoint)
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Post.new(uri)
-        request.set_content_type(CONTENT_TYPE)
+        request.set_content_type(DEFAULT_CONTENT_TYPE)
         request.set_form_data(token_request_params)
         http.request(request)
       end

--- a/app/services/keycloak_oauth/post_token_service.rb
+++ b/app/services/keycloak_oauth/post_token_service.rb
@@ -1,0 +1,41 @@
+require 'net/http'
+
+module KeycloakOauth
+  class PostTokenService
+    DEFAULT_GRANT_TYPE = 'authorization_code'.freeze
+    CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
+
+    attr_reader :request_params, :connection
+
+    def initialize(connection:, request_params:)
+      @connection = connection
+      @request_params = request_params
+    end
+
+    def send_request
+      post_token
+    end
+
+    private
+
+    attr_reader :code, :redirect_uri
+
+    def post_token
+      uri = URI.parse(connection.authentication_endpoint)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Post.new(uri)
+        request.set_content_type(CONTENT_TYPE)
+        request.set_form_data(token_request_params)
+        http.request(request)
+      end
+    end
+
+    def token_request_params
+      {
+        client_id: connection.client_id,
+        client_secret: connection.client_secret,
+        grant_type: DEFAULT_GRANT_TYPE
+      }.merge(request_params)
+    end
+  end
+end

--- a/app/services/keycloak_oauth/post_users_service.rb
+++ b/app/services/keycloak_oauth/post_users_service.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 
 module KeycloakOauth
-  class EmailConflictError < StandardError; end
+  class DuplicationError < StandardError; end
 
   class PostUsersService < KeycloakOauth::AuthorizableService
     CONTENT_TYPE = 'application/json'.freeze
@@ -34,15 +34,16 @@ module KeycloakOauth
       end
     end
 
-    def parsed_response(http_response)
+    def parse_response_body(http_response)
       super
     rescue KeycloakOauth::AuthorizableError => exception
-      raise exception unless is_exception_an_email_conflict?(exception)
-      raise KeycloakOauth::EmailConflictError.new(exception)
+      raise exception unless is_exception_a_duplication?(exception)
+      raise KeycloakOauth::DuplicationError.new(exception)
     end
 
-    def is_exception_an_email_conflict?(exception)
-      exception.message == "User exists with same email"
+    def is_exception_a_duplication?(exception)
+      exception.message == "User exists with same email" ||
+      exception.message == "User exists with same username"
     end
   end
 end

--- a/app/services/keycloak_oauth/post_users_service.rb
+++ b/app/services/keycloak_oauth/post_users_service.rb
@@ -16,7 +16,7 @@ module KeycloakOauth
     end
 
     def send_request
-      parsed_response(post_users)
+      post_users
     end
 
     private

--- a/app/services/keycloak_oauth/post_users_service.rb
+++ b/app/services/keycloak_oauth/post_users_service.rb
@@ -1,0 +1,35 @@
+require 'net/http'
+
+module KeycloakOauth
+  class PostUsersService < KeycloakOauth::AuthorizableService
+    CONTENT_TYPE = 'application/json'.freeze
+
+    attr_reader :request_params, :connection, :user_params
+
+    def initialize(connection:, access_token:, refresh_token:, user_params:)
+      @connection = connection
+      @access_token = access_token
+      @refresh_token = refresh_token
+      @user_params = user_params
+    end
+
+    def send_request
+      parsed_response(post_users)
+    end
+
+    private
+
+    attr_accessor :access_token, :refresh_token
+
+    def post_users
+      uri = URI.parse(connection.post_users_endpoint)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Post.new(uri)
+        request.set_content_type(CONTENT_TYPE)
+        request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
+        request.body = user_params.to_json
+        http.request(request)
+      end
+    end
+  end
+end

--- a/app/services/keycloak_oauth/user_info_retrieval_service.rb
+++ b/app/services/keycloak_oauth/user_info_retrieval_service.rb
@@ -9,8 +9,8 @@ module KeycloakOauth
       @refresh_token = refresh_token
     end
 
-    def retrieve
-      @user_information = parsed_response(get_user)
+    def send_request
+      get_user
     end
 
     private

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -19,13 +19,13 @@ module KeycloakOauth
         access_token: access_token,
         refresh_token: refresh_token
       )
-      service.retrieve
-      service.user_information
+      service.perform
+      service.parsed_response_body
     end
 
     def logout(session:)
       service = KeycloakOauth::LogoutService.new(session)
-      service.logout
+      service.perform
     end
   end
 end

--- a/lib/keycloak_oauth/endpoints.rb
+++ b/lib/keycloak_oauth/endpoints.rb
@@ -20,5 +20,9 @@ module KeycloakOauth
     def logout_endpoint
       "#{auth_url}/realms/#{realm}/protocol/openid-connect/logout"
     end
+
+    def post_users_endpoint
+      "#{auth_url}/admin/realms/#{realm}/users"
+    end
   end
 end

--- a/lib/keycloak_oauth/version.rb
+++ b/lib/keycloak_oauth/version.rb
@@ -1,3 +1,3 @@
 module KeycloakOauth
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end

--- a/spec/endpoints_spec.rb
+++ b/spec/endpoints_spec.rb
@@ -49,8 +49,14 @@ RSpec.describe KeycloakOauth::Endpoints do
   end
 
   describe '#logout_endpoint' do
-    it 'returns scoped user_info_endpoint' do
+    it 'returns scoped logout_endpoint' do
       expect(subject.logout_endpoint).to eq('http://domain/auth/realms/first_realm/protocol/openid-connect/logout')
+    end
+  end
+
+  describe '#post_users_endpoint' do
+    it 'returns scoped post_users_endpoint' do
+      expect(subject.post_users_endpoint).to eq('http://domain/auth/admin/realms/first_realm/users')
     end
   end
 end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe KeycloakOauth::AuthenticationService do
         stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
           to_return(status: [400], body: keycloak_invalid_code_request_error_body)
 
-        expect { subject.authenticate }.to raise_error(KeycloakOauth::AuthenticationError)
+        expect { subject.authenticate }.to raise_error(KeycloakOauth::AuthorizableError)
       end
     end
   end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -4,12 +4,11 @@ require 'support/helpers/keycloak_responses'
 RSpec.describe KeycloakOauth::AuthenticationService do
   include Helpers::KeycloakResponses
 
-  describe '#authenticate' do
+  describe '#perform' do
     subject do
       KeycloakOauth::AuthenticationService.new(
         authentication_params: dummy_authentication_params,
-        session: session,
-        redirect_uri: 'http://example.com/oauth2'
+        session: session
       )
     end
 
@@ -45,7 +44,16 @@ RSpec.describe KeycloakOauth::AuthenticationService do
   def dummy_authentication_params
     {
       code: '8c964a59-288b-4189-a43e-4c128f7a40c5.07f3451d-0331-4e26-9e3c-994011f1a431.94e82291-2a65-4643-9809-a3494a97b43f',
-      session_state: '07f3451d-0331-4e26-9e3c-994011f1a431'
+      session_state: '07f3451d-0331-4e26-9e3c-994011f1a431',
+      redirect_uri: 'http://example.com/oauth2'
     }
   end
 end
+
+
+
+
+
+
+
+

--- a/spec/services/logout_service_spec.rb
+++ b/spec/services/logout_service_spec.rb
@@ -4,16 +4,21 @@ require 'support/helpers/keycloak_responses'
 RSpec.describe KeycloakOauth::LogoutService do
   include Helpers::KeycloakResponses
 
-  describe '#logout' do
+  let(:service) { KeycloakOauth::LogoutService.new(session) }
+
+  describe '#perform' do
     let(:session) { OpenStruct.new(access_token: 'token_A', refresh_token: 'token_B') }
 
-    subject { KeycloakOauth::LogoutService.new(session) }
+    subject { service.perform }
 
     it 'logs out from Keycloak' do
       stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').
         to_return(status: [204], body: nil) # Keycloak replies with an empty body.
 
-      expect(subject.logout).to be_nil
+      subject
+
+      expect(service.http_response.code_type).to eq(Net::HTTPNoContent)
+      expect(service.parsed_response_body).to be_nil
     end
 
     context 'when the access token is invalid' do
@@ -23,7 +28,7 @@ RSpec.describe KeycloakOauth::LogoutService do
         stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').
           to_return(status: [401], body: keycloak_invalid_token_request_error_body)
 
-        expect { subject.logout }.to raise_error(KeycloakOauth::AuthorizableError)
+        expect { subject }.to raise_error(KeycloakOauth::AuthorizableError)
       end
     end
   end

--- a/spec/services/logout_service_spec.rb
+++ b/spec/services/logout_service_spec.rb
@@ -13,10 +13,7 @@ RSpec.describe KeycloakOauth::LogoutService do
       stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/logout').
         to_return(status: [204], body: nil) # Keycloak replies with an empty body.
 
-      service = subject
-      service.logout
-
-      expect(service.logout).to be_nil
+      expect(subject.logout).to be_nil
     end
 
     context 'when the access token is invalid' do

--- a/spec/services/post_token_service_spec.rb
+++ b/spec/services/post_token_service_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::PostTokenService do
+  include Helpers::KeycloakResponses
+
+  describe '#send_request' do
+    let(:connection) { KeycloakOauth.connection }
+
+    subject do
+      KeycloakOauth::PostTokenService.new(
+        connection: connection,
+        request_params: dummy_request_params)
+      end
+
+    context 'when the authorization code can be exchanged for an access token' do
+      it 'retrieves authentication information' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
+          with(body: {
+            client_id: 'a_client',
+            client_secret: 'a_secret',
+            grant_type: 'authorization_code',
+            code: dummy_request_params[:code],
+            redirect_uri: dummy_request_params[:redirect_uri],
+            session_state: dummy_request_params[:session_state]
+          }).to_return(body: keycloak_tokens_request_body)
+
+        response = subject.send_request
+
+        expect(response.code_type).to eq(Net::HTTPOK)
+        expect(response.body).to eq(keycloak_tokens_request_body)
+      end
+    end
+
+    context 'when the authorization code is invalid/has expired' do
+      it 'returns error' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
+          with(body: {
+            client_id: 'a_client',
+            client_secret: 'a_secret',
+            grant_type: 'authorization_code',
+            code: dummy_request_params[:code],
+            redirect_uri: dummy_request_params[:redirect_uri],
+            session_state: dummy_request_params[:session_state]
+          }).to_return(status: [400], body: keycloak_invalid_code_request_error_body)
+
+        response = subject.send_request
+
+        expect(response.code_type).to eq(Net::HTTPBadRequest)
+        expect(response.body).to eq(keycloak_invalid_code_request_error_body)
+      end
+    end
+
+    context 'when some default params are overriden' do
+      let(:dummy_request_params) { { grant_type: 'client_credentials' } }
+      let(:connection) {
+        KeycloakOauth::Connection.new(
+          auth_url: 'http://domain/auth',
+          realm: 'master',
+          client_id: 'admin-cli',
+          client_secret: 'some-admin-secret'
+        )
+      }
+
+      it 'retrieves authentication information' do
+        stub_request(:post, 'http://domain/auth/realms/master/protocol/openid-connect/token').
+          with(body: {
+            client_id: 'admin-cli',
+            client_secret: 'some-admin-secret',
+            grant_type: 'client_credentials'
+          }).to_return(body: keycloak_tokens_request_body)
+
+        response = subject.send_request
+
+        expect(response.code_type).to eq(Net::HTTPOK)
+        expect(response.body).to eq(keycloak_tokens_request_body)
+      end
+    end
+  end
+
+  private
+
+  def dummy_request_params
+    {
+      code: '8c964a59-288b-4189-a43e-4c128f7a40c5.07f3451d-0331-4e26-9e3c-994011f1a431.94e82291-2a65-4643-9809-a3494a97b43f',
+      session_state: '07f3451d-0331-4e26-9e3c-994011f1a431',
+      redirect_uri: 'http://example.com/oauth2'
+    }
+  end
+end

--- a/spec/services/post_users_service_spec.rb
+++ b/spec/services/post_users_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::PostUsersService do
+  include Helpers::KeycloakResponses
+
+  describe '#send_request' do
+    context 'when the user was created on Keycloak' do
+      it 'performs request' do
+        stub_request(:post, 'http://domain/auth/admin/realms/first_realm/users')
+          .with(body: dummy_user_params_as_json)
+          .to_return(status: [201], body: nil) # Keycloak replies with an empty body.
+
+        service = KeycloakOauth::PostUsersService.new(
+          access_token: 'access_token',
+          refresh_token: 'refresh_token',
+          connection: KeycloakOauth.connection,
+          user_params: {
+            firstName: 'TestUser',
+            lastName: 'TestUser',
+            email: 'testuser@example.com',
+            username: 'testuser@example.com'
+          }
+        )
+
+        response = service.send_request
+        expect(response).to be_empty
+      end
+    end
+  end
+
+  private
+
+  def dummy_user_params_as_json
+    "{\"firstName\":\"TestUser\",\"lastName\":\"TestUser\",\"email\":" \
+    "\"testuser@example.com\",\"username\":\"testuser@example.com\"}"
+  end
+end

--- a/spec/services/post_users_service_spec.rb
+++ b/spec/services/post_users_service_spec.rb
@@ -5,26 +5,51 @@ RSpec.describe KeycloakOauth::PostUsersService do
   include Helpers::KeycloakResponses
 
   describe '#send_request' do
+    subject do
+      KeycloakOauth::PostUsersService.new(
+        access_token: 'access_token',
+        refresh_token: 'refresh_token',
+        connection: KeycloakOauth.connection,
+        user_params: {
+          firstName: 'TestUser',
+          lastName: 'TestUser',
+          email: 'testuser@example.com',
+          username: 'testuser@example.com'
+        }
+      )
+    end
+
     context 'when the user was created on Keycloak' do
       it 'performs request' do
         stub_request(:post, 'http://domain/auth/admin/realms/first_realm/users')
           .with(body: dummy_user_params_as_json)
           .to_return(status: [201], body: nil) # Keycloak replies with an empty body.
 
-        service = KeycloakOauth::PostUsersService.new(
-          access_token: 'access_token',
-          refresh_token: 'refresh_token',
-          connection: KeycloakOauth.connection,
-          user_params: {
-            firstName: 'TestUser',
-            lastName: 'TestUser',
-            email: 'testuser@example.com',
-            username: 'testuser@example.com'
-          }
-        )
 
-        response = service.send_request
+        response = subject.send_request
         expect(response).to be_empty
+      end
+    end
+
+    context 'when Keycloak returned an error' do
+      context 'when a user with this email already exists' do
+        it 'raises an EmailConflictError' do
+          stub_request(:post, 'http://domain/auth/admin/realms/first_realm/users')
+            .with(body: dummy_user_params_as_json)
+            .to_return(status: [409], body: email_conflict_error_as_json)
+
+          expect { subject.send_request }.to raise_error(KeycloakOauth::EmailConflictError)
+        end
+      end
+
+      context 'when the access token has expired' do
+        it 'raises an AuthorizableError' do
+          stub_request(:post, 'http://domain/auth/admin/realms/first_realm/users')
+            .with(body: dummy_user_params_as_json)
+            .to_return(status: [401], body: keycloak_invalid_token_request_error_body)
+
+          expect { subject.send_request }.to raise_error(KeycloakOauth::AuthorizableError)
+        end
       end
     end
   end
@@ -34,5 +59,9 @@ RSpec.describe KeycloakOauth::PostUsersService do
   def dummy_user_params_as_json
     "{\"firstName\":\"TestUser\",\"lastName\":\"TestUser\",\"email\":" \
     "\"testuser@example.com\",\"username\":\"testuser@example.com\"}"
+  end
+
+  def email_conflict_error_as_json
+    "{\"errorMessage\":\"User exists with same email\"}"
   end
 end

--- a/spec/services/post_users_service_spec.rb
+++ b/spec/services/post_users_service_spec.rb
@@ -36,12 +36,22 @@ RSpec.describe KeycloakOauth::PostUsersService do
 
     context 'when Keycloak returned an error' do
       context 'when a user with this email already exists' do
-        it 'raises an EmailConflictError' do
+        it 'raises a DuplicationError' do
           stub_request(:post, 'http://domain/auth/admin/realms/first_realm/users')
             .with(body: dummy_user_params_as_json)
             .to_return(status: [409], body: email_conflict_error_as_json)
 
-          expect { subject }.to raise_error(KeycloakOauth::EmailConflictError)
+          expect { subject }.to raise_error(KeycloakOauth::DuplicationError)
+        end
+      end
+
+      context 'when a user with this username already exists' do
+        it 'raises a DuplicationError' do
+          stub_request(:post, 'http://domain/auth/admin/realms/first_realm/users')
+            .with(body: dummy_user_params_as_json)
+            .to_return(status: [409], body: username_conflict_error_as_json)
+
+          expect { subject }.to raise_error(KeycloakOauth::DuplicationError)
         end
       end
 
@@ -66,5 +76,9 @@ RSpec.describe KeycloakOauth::PostUsersService do
 
   def email_conflict_error_as_json
     "{\"errorMessage\":\"User exists with same email\"}"
+  end
+
+  def username_conflict_error_as_json
+    "{\"errorMessage\":\"User exists with same username\"}"
   end
 end


### PR DESCRIPTION
This PR implements the following:
- I split the `AuthenticationService` into two separate services (as they actually perform two different things). One aims to get the access and refresh tokens and the other stores them into the session.
- Extracting the logic making the request to `POST token` allows us to reuse this in oder scenarios (and not just when a user logs in through a UI).
- Refactored services which communicate with Keycloak to be more flexible (i.e. to accept customisable params to be sent to Keycloak). For example, in certain calls to the `token` endpoint, we need to pass in a `redirect_uri`, whereas in others we don't as they don't trigger a callback).
- Implemented logic for creating a Keycloak user via the API.
- Added more error handling. 

Note about the `AuthorizableService`:
Previously, we were always returning the parsed response after subclasses of this class performed. However, in some instances we need to access the actual HTTP response object. So I standardised a bit the subclasses to have the following structure:
- they must implement a `send_request` method
- the parent class exposes this behaviour using the `perform` method. This also ensures that the `@parsed_http_response` and `@http_response` objects are initialised. 
- therefore, once the `perform` method is called, the calling object can easily have access to the HTTP response and its parsed body. 