### PR TITLE
Get single user and trigger user emails

### DIFF
--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -25,6 +25,8 @@ module KeycloakOauth
         acc
       end
 
+      log_unsupported_params(given_params.keys - supported_params)
+
       uri.query = URI.encode_www_form(query_params) if query_params.values.any?
       uri
     end
@@ -60,6 +62,12 @@ module KeycloakOauth
         return response
       else
         'Unexpected Keycloak error'
+      end
+    end
+
+    def self.log_unsupported_params(query_params)
+      query_params.each do |query_param|
+        Rails.logger.warn { "Unsupported query param was passed in: #{query_param}" }
       end
     end
   end

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -5,7 +5,8 @@ module KeycloakOauth
 
   class AuthorizableService
     HTTP_SUCCESS_CODES = [Net::HTTPOK, Net::HTTPNoContent, Net::HTTPCreated]
-    DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
+    CONTENT_TYPE_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded'.freeze
+    CONTENT_TYPE_JSON = 'application/json'.freeze
     AUTHORIZATION_HEADER = 'Authorization'.freeze
 
     attr_reader :http_response, :parsed_response_body

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -2,6 +2,7 @@ require 'net/http'
 
 module KeycloakOauth
   class AuthorizableError < StandardError; end
+  class NotFoundError < StandardError; end
 
   class AuthorizableService
     HTTP_SUCCESS_CODES = [Net::HTTPOK, Net::HTTPNoContent, Net::HTTPCreated]
@@ -40,6 +41,8 @@ module KeycloakOauth
           return response['errorMessage']
         elsif response.has_key?('error_description')
           return response['error_description']
+        elsif response.has_key?('error')
+          return response['error']
         end
       when 'String'
         return response

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -17,6 +17,18 @@ module KeycloakOauth
       @parsed_response_body ||= parse_response_body(http_response)
     end
 
+    def self.uri_with_supported_query_params(url, supported_params, given_params)
+      uri = URI.parse(url)
+
+      query_params = supported_params.inject({}) do |acc, query_param|
+        acc[query_param] = given_params[query_param] if given_params[query_param].present?
+        acc
+      end
+
+      uri.query = URI.encode_www_form(query_params) if query_params.values.any?
+      uri
+    end
+
     private
 
     def parse_response_body(http_response)

--- a/app/services/keycloak_oauth/get_users_service.rb
+++ b/app/services/keycloak_oauth/get_users_service.rb
@@ -1,0 +1,42 @@
+require 'net/http'
+
+module KeycloakOauth
+  class GetUsersService < KeycloakOauth::AuthorizableService
+    SUPPORTED_QUERY_PARAMS = %i(briefRepresentation email first firstName lastName max search username)
+
+    attr_reader :connection, :options
+
+    def initialize(connection:, access_token:, refresh_token:, options: {})
+      @connection = connection
+      @access_token = access_token
+      @refresh_token = refresh_token
+      @options = options
+    end
+
+    def send_request
+      get_users
+    end
+
+    private
+
+    attr_reader :access_token, :refresh_token
+
+    def get_users
+      uri = build_uri
+
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Get.new(uri)
+        request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
+        http.request(request)
+      end
+    end
+
+    def build_uri
+      self.class.uri_with_supported_query_params(
+        connection.users_endpoint,
+        SUPPORTED_QUERY_PARAMS,
+        options
+      )
+    end
+  end
+end

--- a/app/services/keycloak_oauth/logout_service.rb
+++ b/app/services/keycloak_oauth/logout_service.rb
@@ -18,7 +18,7 @@ module KeycloakOauth
       uri = URI.parse(KeycloakOauth.connection.logout_endpoint)
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Post.new(uri)
-        request.set_content_type(DEFAULT_CONTENT_TYPE)
+        request.set_content_type(CONTENT_TYPE_X_WWW_FORM_URLENCODED)
         request.set_form_data(logout_request_params)
         request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
         http.request(request)

--- a/app/services/keycloak_oauth/post_token_service.rb
+++ b/app/services/keycloak_oauth/post_token_service.rb
@@ -23,7 +23,7 @@ module KeycloakOauth
       uri = URI.parse(connection.authentication_endpoint)
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Post.new(uri)
-        request.set_content_type(DEFAULT_CONTENT_TYPE)
+        request.set_content_type(CONTENT_TYPE_X_WWW_FORM_URLENCODED)
         request.set_form_data(token_request_params)
         http.request(request)
       end

--- a/app/services/keycloak_oauth/post_users_service.rb
+++ b/app/services/keycloak_oauth/post_users_service.rb
@@ -22,7 +22,7 @@ module KeycloakOauth
     attr_accessor :access_token, :refresh_token
 
     def post_users
-      uri = URI.parse(connection.post_users_endpoint)
+      uri = URI.parse(connection.users_endpoint)
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Post.new(uri)
         request.set_content_type(CONTENT_TYPE_JSON)

--- a/app/services/keycloak_oauth/post_users_service.rb
+++ b/app/services/keycloak_oauth/post_users_service.rb
@@ -4,8 +4,6 @@ module KeycloakOauth
   class DuplicationError < StandardError; end
 
   class PostUsersService < KeycloakOauth::AuthorizableService
-    CONTENT_TYPE = 'application/json'.freeze
-
     attr_reader :request_params, :connection, :user_params
 
     def initialize(connection:, access_token:, refresh_token:, user_params:)
@@ -27,7 +25,7 @@ module KeycloakOauth
       uri = URI.parse(connection.post_users_endpoint)
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Post.new(uri)
-        request.set_content_type(CONTENT_TYPE)
+        request.set_content_type(CONTENT_TYPE_JSON)
         request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
         request.body = user_params.to_json
         http.request(request)

--- a/app/services/keycloak_oauth/put_execute_actions_email_service.rb
+++ b/app/services/keycloak_oauth/put_execute_actions_email_service.rb
@@ -24,7 +24,7 @@ module KeycloakOauth
     attr_accessor :access_token, :refresh_token
 
     def put_execute_actions_email
-      uri = uri_with_query_params
+      uri = build_uri
 
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Put.new(uri)
@@ -36,16 +36,12 @@ module KeycloakOauth
       end
     end
 
-    def uri_with_query_params
-      uri = URI.parse(connection.put_execute_actions_email_endpoint(user_id))
-
-      query_params = SUPPORTED_QUERY_PARAMS.inject({}) do |acc, query_param|
-        acc[query_param] = options[query_param] if options[query_param].present?
-        acc
-      end
-
-      uri.query = URI.encode_www_form(query_params) if query_params.values.any?
-      uri
+    def build_uri
+      self.class.uri_with_supported_query_params(
+        connection.put_execute_actions_email_endpoint(user_id),
+        SUPPORTED_QUERY_PARAMS,
+        options
+      )
     end
 
     def parse_response_body(http_response)

--- a/app/services/keycloak_oauth/put_execute_actions_email_service.rb
+++ b/app/services/keycloak_oauth/put_execute_actions_email_service.rb
@@ -1,0 +1,47 @@
+require 'net/http'
+
+module KeycloakOauth
+  class PutExecuteActionsEmailService < KeycloakOauth::AuthorizableService
+    attr_reader :connection, :user_id, :actions, :options
+
+    def initialize(connection: KeycloakOauth.connection, access_token:, refresh_token:, user_id:, actions:, options: {})
+      @connection = connection
+      @access_token = access_token
+      @refresh_token = refresh_token
+      @user_id = user_id
+      @actions = actions
+      @options = options
+    end
+
+    def send_request
+      put_execute_actions_email
+    end
+
+    private
+
+    attr_accessor :access_token, :refresh_token
+
+    def put_execute_actions_email
+      uri = URI.parse(connection.put_execute_actions_email_endpoint(user_id))
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Put.new(uri)
+        request.set_content_type(CONTENT_TYPE_JSON)
+        request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
+        request.body = actions.to_json
+        req = http.request(request)
+        req
+      end
+    end
+
+    def parse_response_body(http_response)
+      super
+    rescue KeycloakOauth::AuthorizableError => exception
+      raise exception unless not_found_error?(exception)
+      raise KeycloakOauth::NotFoundError.new(exception)
+    end
+
+    def not_found_error?(exception)
+      exception.message == "User not found"
+    end
+  end
+end

--- a/app/services/keycloak_oauth/put_execute_actions_email_service.rb
+++ b/app/services/keycloak_oauth/put_execute_actions_email_service.rb
@@ -31,8 +31,7 @@ module KeycloakOauth
         request.set_content_type(CONTENT_TYPE_JSON)
         request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
         request.body = actions.to_json
-        req = http.request(request)
-        req
+        http.request(request)
       end
     end
 

--- a/app/services/keycloak_oauth/user_info_retrieval_service.rb
+++ b/app/services/keycloak_oauth/user_info_retrieval_service.rb
@@ -21,7 +21,7 @@ module KeycloakOauth
       uri = URI.parse(KeycloakOauth.connection.user_info_endpoint)
       Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
         request = Net::HTTP::Get.new(uri)
-        request.set_content_type(DEFAULT_CONTENT_TYPE)
+        request.set_content_type(CONTENT_TYPE_X_WWW_FORM_URLENCODED)
         request[AUTHORIZATION_HEADER] = "Bearer #{access_token}"
         http.request(request)
       end

--- a/lib/keycloak_oauth/endpoints.rb
+++ b/lib/keycloak_oauth/endpoints.rb
@@ -26,7 +26,7 @@ module KeycloakOauth
     end
 
     def put_execute_actions_email_endpoint(user_id)
-      "#{auth_url}/realms/#{realm}/users/#{user_id}/execute-actions-email"
+      "#{auth_url}/admin/realms/#{realm}/users/#{user_id}/execute-actions-email"
     end
   end
 end

--- a/lib/keycloak_oauth/endpoints.rb
+++ b/lib/keycloak_oauth/endpoints.rb
@@ -24,5 +24,9 @@ module KeycloakOauth
     def post_users_endpoint
       "#{auth_url}/admin/realms/#{realm}/users"
     end
+
+    def put_execute_actions_email_endpoint(user_id)
+      "#{auth_url}/realms/#{realm}/users/#{user_id}/execute-actions-email"
+    end
   end
 end

--- a/lib/keycloak_oauth/endpoints.rb
+++ b/lib/keycloak_oauth/endpoints.rb
@@ -21,7 +21,7 @@ module KeycloakOauth
       "#{auth_url}/realms/#{realm}/protocol/openid-connect/logout"
     end
 
-    def post_users_endpoint
+    def users_endpoint
       "#{auth_url}/admin/realms/#{realm}/users"
     end
 

--- a/lib/keycloak_oauth/version.rb
+++ b/lib/keycloak_oauth/version.rb
@@ -1,3 +1,3 @@
 module KeycloakOauth
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end

--- a/spec/endpoints_spec.rb
+++ b/spec/endpoints_spec.rb
@@ -59,4 +59,13 @@ RSpec.describe KeycloakOauth::Endpoints do
       expect(subject.post_users_endpoint).to eq('http://domain/auth/admin/realms/first_realm/users')
     end
   end
+
+  describe '#put_execute_actions_email_endpoint' do
+    let(:user_id) { 'abcdefgh' }
+
+    it 'returns scoped put_execute_actions_email_endpoint' do
+      expect(subject.put_execute_actions_email_endpoint(user_id))
+        .to eq('http://domain/auth/realms/first_realm/users/abcdefgh/execute-actions-email')
+    end
+  end
 end

--- a/spec/endpoints_spec.rb
+++ b/spec/endpoints_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe KeycloakOauth::Endpoints do
     end
   end
 
-  describe '#post_users_endpoint' do
-    it 'returns scoped post_users_endpoint' do
-      expect(subject.post_users_endpoint).to eq('http://domain/auth/admin/realms/first_realm/users')
+  describe '#users_endpoint' do
+    it 'returns scoped users_endpoint' do
+      expect(subject.users_endpoint).to eq('http://domain/auth/admin/realms/first_realm/users')
     end
   end
 

--- a/spec/endpoints_spec.rb
+++ b/spec/endpoints_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe KeycloakOauth::Endpoints do
 
     it 'returns scoped put_execute_actions_email_endpoint' do
       expect(subject.put_execute_actions_email_endpoint(user_id))
-        .to eq('http://domain/auth/realms/first_realm/users/abcdefgh/execute-actions-email')
+        .to eq('http://domain/auth/admin/realms/first_realm/users/abcdefgh/execute-actions-email')
     end
   end
 end

--- a/spec/services/get_users_service.rb
+++ b/spec/services/get_users_service.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::GetUsersService do
+  include Helpers::KeycloakResponses
+
+  let(:service) do
+    KeycloakOauth::GetUsersService.new(
+      connection: KeycloakOauth.connection,
+      access_token: access_token,
+      refresh_token: refresh_token
+    )
+  end
+
+  describe '#perform' do
+    subject { service.perform }
+
+    context 'when the users can be retrieved from Keycloak' do
+      context 'when no filtering options are passed in' do
+        it 'retrieves all users' do
+          stub_request(:get, 'http://domain/auth/admin/realms/first_realm/users')
+            .to_return(status: [200], body: keycloak_users_request_body)
+
+          subject
+
+          expect(service.http_response.code_type).to eq(Net::HTTPOK)
+          expect(service.parsed_response_body).to eq([{
+            'id' => 'fd62fb4e-04e1-4660-a961-f4592b95bb45',
+            'createdTimestamp' => 1606123457175,
+            'username' => 'user_A',
+            'enabled' => true,
+            'totp' => false,
+            'emailVerified' => false,
+            'firstName' => 'User A First Name',
+            'lastName' => 'User A Last Name',
+            'email' => 'user_A@example.com',
+            'disableableCredentialTypes' => [],
+            'requiredActions' => [],
+            'notBefore' => 0,
+            'access' => {
+              'manageGroupMembership' => true,
+              'view' => true,
+              'mapRoles' => true,
+              'impersonate' => false,
+              'manage' => true
+              }
+            }]
+          )
+        end
+      end
+
+      context 'when some filtering options are passed in' do
+        let(:service) do
+          KeycloakOauth::GetUsersService.new(
+            connection: KeycloakOauth.connection,
+            access_token: access_token,
+            refresh_token: refresh_token,
+            options: { username: 'user_A', email: 'user_A@example.com' }
+          )
+        end
+
+        it 'passes options to Keycloak' do
+          url = 'http://domain/auth/admin/realms/first_realm/users?username=user_A' \
+                '&email=user_A@example.com'
+
+          stub_request(:get, url)
+            .to_return(status: [200], body: keycloak_users_request_body)
+
+          subject
+
+          expect(service.http_response.code_type).to eq(Net::HTTPOK)
+          expect(service.parsed_response_body).to eq([{
+            'id' => 'fd62fb4e-04e1-4660-a961-f4592b95bb45',
+            'createdTimestamp' => 1606123457175,
+            'username' => 'user_A',
+            'enabled' => true,
+            'totp' => false,
+            'emailVerified' => false,
+            'firstName' => 'User A First Name',
+            'lastName' => 'User A Last Name',
+            'email' => 'user_A@example.com',
+            'disableableCredentialTypes' => [],
+            'requiredActions' => [],
+            'notBefore' => 0,
+            'access' => {
+              'manageGroupMembership' => true,
+              'view' => true,
+              'mapRoles' => true,
+              'impersonate' => false,
+              'manage' => true
+              }
+            }]
+          )
+        end
+      end
+
+      context 'when some unsupported filtering options are passed in' do
+        let(:service) do
+          KeycloakOauth::GetUsersService.new(
+            connection: KeycloakOauth.connection,
+            access_token: access_token,
+            refresh_token: refresh_token,
+            options: { unsupported_param: 'user_A' }
+          )
+        end
+
+        it 'does not pass unsupported filters to Keycloak' do
+          stub_request(:get, 'http://domain/auth/admin/realms/first_realm/users')
+            .to_return(status: [200], body: keycloak_users_request_body)
+
+          subject
+
+          expect(service.http_response.code_type).to eq(Net::HTTPOK)
+          expect(service.parsed_response_body).to eq([{
+            'id' => 'fd62fb4e-04e1-4660-a961-f4592b95bb45',
+            'createdTimestamp' => 1606123457175,
+            'username' => 'user_A',
+            'enabled' => true,
+            'totp' => false,
+            'emailVerified' => false,
+            'firstName' => 'User A First Name',
+            'lastName' => 'User A Last Name',
+            'email' => 'user_A@example.com',
+            'disableableCredentialTypes' => [],
+            'requiredActions' => [],
+            'notBefore' => 0,
+            'access' => {
+              'manageGroupMembership' => true,
+              'view' => true,
+              'mapRoles' => true,
+              'impersonate' => false,
+              'manage' => true
+              }
+            }]
+          )
+        end
+      end
+    end
+
+    context 'when no users are found in Keycloak' do
+      it 'returns an empty array' do
+        stub_request(:get, 'http://domain/auth/admin/realms/first_realm/users')
+          .to_return(status: [200], body: "[]")
+
+        subject
+
+        expect(service.http_response.code_type).to eq(Net::HTTPOK)
+        expect(service.parsed_response_body).to be_empty
+      end
+    end
+
+    context 'when the access token is invalid' do
+      let(:access_token) { 'some_token' }
+
+      it 'raises an error' do
+        stub_request(:get, 'http://domain/auth/admin/realms/first_realm/users').
+          to_return(status: [401], body: keycloak_invalid_token_request_error_body)
+
+        expect { subject }.to raise_error(KeycloakOauth::AuthorizableError)
+      end
+    end
+  end
+end

--- a/spec/services/put_execut_actions_email_service_spec.rb
+++ b/spec/services/put_execut_actions_email_service_spec.rb
@@ -52,6 +52,96 @@ RSpec.describe KeycloakOauth::PutExecuteActionsEmailService do
         end
       end
     end
+
+    context 'when additional options are passed in' do
+      context 'AND all the options is supported' do
+        let(:service) do
+          KeycloakOauth::PutExecuteActionsEmailService.new(
+            connection: KeycloakOauth.connection,
+            access_token: 'access_token',
+            refresh_token: 'refresh_token',
+            user_id: 'existing-user-id',
+            actions: actions,
+            options: {
+              lifespan: 1234,
+              redirect_uri: 'http://example.com'
+            }
+          )
+        end
+
+        it 'passes them to Keycloak' do
+          url = 'http://domain/auth/admin/realms/first_realm/users/existing-user-id/' \
+          'execute-actions-email?lifespan=1234&redirect_uri=http://example.com'
+
+          stub_request(:put, url)
+            .with(body: dummy_actions_as_json)
+            .to_return(status: [200], body: "") # Keycloak replies with an empty body.
+
+          subject
+
+          expect(service.http_response.code_type).to eq(Net::HTTPOK)
+          expect(service.parsed_response_body).to be_empty
+        end
+      end
+
+      context 'AND only some options are supported' do
+        let(:service) do
+          KeycloakOauth::PutExecuteActionsEmailService.new(
+            connection: KeycloakOauth.connection,
+            access_token: 'access_token',
+            refresh_token: 'refresh_token',
+            user_id: 'existing-user-id',
+            actions: actions,
+            options: {
+              lifespan: 1234,
+              redirect_uri: 'http://example.com',
+              unsupported_param: 'some_value'
+            }
+          )
+        end
+
+        it 'only passes the supported options to Keycloak' do
+          url = 'http://domain/auth/admin/realms/first_realm/users/existing-user-id/' \
+          'execute-actions-email?lifespan=1234&redirect_uri=http://example.com'
+
+          stub_request(:put, url)
+            .with(body: dummy_actions_as_json)
+            .to_return(status: [200], body: "") # Keycloak replies with an empty body.
+
+          subject
+
+          expect(service.http_response.code_type).to eq(Net::HTTPOK)
+          expect(service.parsed_response_body).to be_empty
+        end
+      end
+
+      context 'AND none of the options are not supported' do
+        let(:service) do
+          KeycloakOauth::PutExecuteActionsEmailService.new(
+            connection: KeycloakOauth.connection,
+            access_token: 'access_token',
+            refresh_token: 'refresh_token',
+            user_id: 'existing-user-id',
+            actions: actions,
+            options: {
+              unsupported_param_1: 'some_value_1',
+              unsupported_param_2: 'some_value_2'
+            }
+          )
+        end
+
+        it 'does not pass the options to Keycloak' do
+          stub_request(:put, 'http://domain/auth/admin/realms/first_realm/users/existing-user-id/execute-actions-email')
+            .with(body: dummy_actions_as_json)
+            .to_return(status: [200], body: "") # Keycloak replies with an empty body.
+
+          subject
+
+          expect(service.http_response.code_type).to eq(Net::HTTPOK)
+          expect(service.parsed_response_body).to be_empty
+        end
+      end
+    end
   end
 
   private

--- a/spec/services/put_execut_actions_email_service_spec.rb
+++ b/spec/services/put_execut_actions_email_service_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::PutExecuteActionsEmailService do
+  include Helpers::KeycloakResponses
+
+  let(:service) do
+    KeycloakOauth::PutExecuteActionsEmailService.new(
+      connection: KeycloakOauth.connection,
+      access_token: 'access_token',
+      refresh_token: 'refresh_token',
+      user_id: 'existing-user-id',
+      actions: actions
+    )
+  end
+  let(:actions) { ['UPDATE_PASSWORD', 'VERIFY_EMAIL'] }
+
+  describe '#perform' do
+    subject { service.perform }
+
+    context 'when the actions were successfully enabled in Keycloak' do
+      it 'performs request' do
+        stub_request(:put, 'http://domain/auth/admin/realms/first_realm/users/existing-user-id/execute-actions-email')
+          .with(body: dummy_actions_as_json)
+          .to_return(status: [200], body: "") # Keycloak replies with an empty body.
+
+        subject
+
+        expect(service.http_response.code_type).to eq(Net::HTTPOK)
+        expect(service.parsed_response_body).to be_empty
+      end
+    end
+
+    context 'when Keycloak returned an error' do
+      context 'when a user with the given ID cannot be found in Keycloak' do
+        it 'raises a NotFound error' do
+          stub_request(:put, 'http://domain/auth/admin/realms/first_realm/users/existing-user-id/execute-actions-email')
+            .with(body: dummy_actions_as_json)
+            .to_return(status: [404], body: keycloak_user_not_found_error_body)
+
+          expect { subject }.to raise_error(KeycloakOauth::NotFoundError)
+        end
+      end
+
+      context 'when the access token has expired' do
+        it 'raises an AuthorizableError' do
+          stub_request(:put, 'http://domain/auth/admin/realms/first_realm/users/existing-user-id/execute-actions-email')
+            .with(body: dummy_actions_as_json)
+            .to_return(status: [401], body: keycloak_invalid_token_request_error_body)
+
+          expect { subject }.to raise_error(KeycloakOauth::AuthorizableError)
+        end
+      end
+    end
+  end
+
+  private
+
+  def dummy_actions_as_json
+    "[\"UPDATE_PASSWORD\",\"VERIFY_EMAIL\"]"
+  end
+
+  def keycloak_user_not_found_error_body
+    "{\"error\":\"User not found\"}"
+  end
+end

--- a/spec/services/user_info_retrieval_service_spec.rb
+++ b/spec/services/user_info_retrieval_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe KeycloakOauth::UserInfoRetrievalService do
     subject { service.perform }
 
     context 'when the user information can be retrieved from Keycloak' do
-      it 'retrieves authentication information and stores it in session' do
+      it 'retrieves user information' do
         stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
           to_return(body: keycloak_user_info_request_body)
 

--- a/spec/support/helpers/keycloak_responses.rb
+++ b/spec/support/helpers/keycloak_responses.rb
@@ -33,5 +33,14 @@ module Helpers
     def keycloak_invalid_token_request_error_body
       "{\"error\":\"invalid_token\",\"error_description\":\"Token invalid: Failed to parse JWT\"}"
     end
+
+    def keycloak_users_request_body
+      "[{\"id\":\"fd62fb4e-04e1-4660-a961-f4592b95bb45\",\"createdTimestamp\":1606123457175" \
+      ",\"username\":\"user_A\",\"enabled\":true,\"totp\":false,\"" \
+      "emailVerified\":false,\"firstName\":\"User A First Name\",\"lastName\":" \
+      "\"User A Last Name\",\"email\":\"user_A@example.com\",\"disableableCredentialTypes\":[]" \
+      ",\"requiredActions\":[],\"notBefore\":0,\"access\":{\"manageGroupMembership\":true" \
+      ",\"view\":true,\"mapRoles\":true,\"impersonate\":false,\"manage\":true}}]"
+    end
   end
 end


### PR DESCRIPTION
This PR enables a host app to get a user's ID and trigger email actions for this user.

The email actions endpoint requires an ID (and not username, for example), which is why we need to enable retrieving a single user based on username.

- Adding a service to get users (this service can be used for retrieving a single user - if the username is passed in, it will always retrieve a single user, as the username is unique in Keycloak).
- Adding a service to trigger email actions.
- Adding a mechanism for dynamically setting query params on Keycloak URIs (based on what params are supported)