### PR TITLE
Bump version and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2021-07-09
+
+### Breaking
+
+- Removed support for Ruby < 2.6
+
+### Added
+
+- Testing for Ruby 3.0
+
+### Changed
+
+- Updated `rails` and `activerecord_session_store` for dummy app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keycloak_oauth (0.1.10)
+    keycloak_oauth (1.0.0)
       rails (~> 6.0.3, >= 6.0.3.2)
 
 GEM

--- a/lib/keycloak_oauth/version.rb
+++ b/lib/keycloak_oauth/version.rb
@@ -1,3 +1,3 @@
 module KeycloakOauth
-  VERSION = "0.1.10"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
This PR bumps the Gem's version to 1.0.0 (because of the breaking change introduced with #18) and adds a changelog to note that change.