### PR TITLE
Remove generated README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # KeycloakOauth
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/keycloak_oauth`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+[Keycloak](https://www.keycloak.org) integration for Ruby on Rails.
 
 ## Installation
 
@@ -112,7 +110,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/keycloak_oauth. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/keycloak_oauth/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/simplificator/keycloak_oauth. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/simplificator/keycloak_oauth/blob/master/CODE_OF_CONDUCT.md).
 
 
 ## License
@@ -121,4 +119,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the KeycloakOauth project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/keycloak_oauth/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the KeycloakOauth project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/simplificator/keycloak_oauth/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
I noticed that the README still contained some boilerplate even though the gem has been out for a while. This could be confusing for potential users of the library.

This pull request removes placeholder text. I did not try to write a longer description as I don't have experience with Keycloak or `keycloak_oauth`.