### PR TITLE
Improve default usage scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ end
 This then allows you to access the `KeycloakOauth` APIs:
 `KeycloakOauth.connection.authorization_endpoint`
 
+Ensure you have `default_url_options` set. Here
+is an example of `default_url_options` appropriate for a development environment
+in `config/environments/development.rb`:
+
+```ruby
+config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+```
+
 You can allow the user to log in with Keycloak by adding adding a link that points to `KeycloakOauth.connection.authorization_endpoint`:
 e.g.
 `<%= link_to 'Login with Keycloak', KeycloakOauth.connection.authorization_endpoint %>`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ in `config/environments/development.rb`:
 config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 ```
 
-You can allow the user to log in with Keycloak by adding adding a link that points to `KeycloakOauth.connection.authorization_endpoint`:
+You can allow the user to log in with Keycloak by adding a link that points to `KeycloakOauth.connection.authorization_endpoint`:
 e.g.
 `<%= link_to 'Login with Keycloak', KeycloakOauth.connection.authorization_endpoint(options: { redirect_uri: keycloak_oauth.oauth2_url }) %>`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Or install it yourself as:
 
 ### Using `keycloak_oauth` in a Ruby on Rails app
 
+Unless you plan to overwrite the oauth callback controller (see further below), mount the Rails engine into your application by specifying the following in `config/routes.rb`
+
+```ruby
+mount KeycloakOauth::Engine => "/keycloak_oauth"
+```
+
 The configuration must be defined in the app by initialising the relevant attributes within a configuration block. For example, you could add an initializer script called `keycloak_oauth.rb` holding the following code:
 
 ```ruby
@@ -42,7 +48,8 @@ e.g.
 
 Once authentication is performed, the access and refresh tokens are stored in the session and can be used in your app as wished.
 
-***Customising redirect URIs***
+### Customising redirect URIs
+
 There are situations where you would want to customise the oauth2 route (e.g. to use a localised version of the callback URL).
 In this case, you can do the following:
 - add a controller to your app: e.g. `CallbackOverrides`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
 You can allow the user to log in with Keycloak by adding adding a link that points to `KeycloakOauth.connection.authorization_endpoint`:
 e.g.
-`<%= link_to 'Login with Keycloak', KeycloakOauth.connection.authorization_endpoint %>`
+`<%= link_to 'Login with Keycloak', KeycloakOauth.connection.authorization_endpoint(options: { redirect_uri: keycloak_oauth.oauth2_url }) %>`
 
 Once authentication is performed, the access and refresh tokens are stored in the session and can be used in your app as wished. As the session can become larger than we can store in a cookie (`CookieOverflow` exception), we recommend to use [activerecord-session_store](https://github.com/rails/activerecord-session_store).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can allow the user to log in with Keycloak by adding adding a link that poin
 e.g.
 `<%= link_to 'Login with Keycloak', KeycloakOauth.connection.authorization_endpoint %>`
 
-Once authentication is performed, the access and refresh tokens are stored in the session and can be used in your app as wished.
+Once authentication is performed, the access and refresh tokens are stored in the session and can be used in your app as wished. As the session can become larger than we can store in a cookie (`CookieOverflow` exception), we recommend to use [activerecord-session_store](https://github.com/rails/activerecord-session_store).
 
 ### Customising redirect URIs
 

--- a/app/controllers/keycloak_oauth/callbacks_controller.rb
+++ b/app/controllers/keycloak_oauth/callbacks_controller.rb
@@ -24,8 +24,6 @@ module KeycloakOauth
     def map_authenticatable_if_implemented(request)
       if self.class.method_defined?(:map_authenticatable)
         map_authenticatable(request)
-      else
-        raise NotImplementedError.new('User mapping must be handled by the host app. See README for more information.')
       end
     end
 

--- a/app/controllers/keycloak_oauth/callbacks_controller.rb
+++ b/app/controllers/keycloak_oauth/callbacks_controller.rb
@@ -36,7 +36,7 @@ module KeycloakOauth
       main_app.url_for(only_path: false, overwrite_params: nil)
     rescue ActionController::UrlGenerationError
       # If the host app does not override the oauth2 path, use the engine's path.
-      oauth2_path
+      oauth2_url
     end
   end
 end

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -36,18 +36,5 @@ RSpec.describe KeycloakOauth::CallbacksController, type: :controller do
         expect(subject).to redirect_to('/')
       end
     end
-
-    context 'when the host app does not implement map_authenticatable' do
-      it 'redirects to root path' do
-        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
-          to_return(body: keycloak_tokens_request_body)
-        stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
-          to_return(body: keycloak_user_info_request_body)
-
-        allow(described_class).to receive(:method_defined?).with(:map_authenticatable).and_return(false)
-
-        expect{ subject }.to raise_error(NotImplementedError)
-      end
-    end
   end
 end


### PR DESCRIPTION
With this PR, we extend documentation to improve on-boarding when using the gem with default configuration. There is also a bugfix for the redirect uri when not overwriting the oauth callback controller in the host application.

Closes #27 