### PR TITLE
Refresh token workflow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keycloak_oauth (1.0.0)
+    keycloak_oauth (1.1.0)
       rails (>= 6.0)
 
 GEM
@@ -85,7 +85,7 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
-    globalid (0.5.2)
+    globalid (1.0.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
     i18n (1.8.10)
@@ -95,9 +95,9 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (1.0.1)
+    marcel (1.0.2)
     method_source (1.0.0)
-    mini_mime (1.1.1)
+    mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     multi_json (1.15.0)
@@ -155,16 +155,17 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    sprockets (4.0.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.2)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     thor (1.1.0)
     thread_safe (0.3.6)
+    timecop (0.9.5)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     webmock (3.13.0)
@@ -186,7 +187,8 @@ DEPENDENCIES
   keycloak_oauth!
   rspec-rails
   sqlite3
+  timecop
   webmock
 
 BUNDLED WITH
-   2.2.16
+   2.2.32

--- a/app/services/keycloak_oauth/authentication_service.rb
+++ b/app/services/keycloak_oauth/authentication_service.rb
@@ -1,7 +1,9 @@
 module KeycloakOauth
   class AuthenticationService
     ACCESS_TOKEN_KEY = 'access_token'.freeze
+    ACCESS_TOKEN_EXPIRES_IN = 'expires_in'.freeze
     REFRESH_TOKEN_KEY = 'refresh_token'.freeze
+    REFRESH_TOKEN_EXPIRES_IN = 'refresh_expires_in'.freeze
 
     attr_reader :session, :authentication_params
 
@@ -11,21 +13,26 @@ module KeycloakOauth
     end
 
     def authenticate
+      request_time = Time.zone.now
+
       post_token_service = KeycloakOauth::PostAuthorizationCodeService.new(
         connection: KeycloakOauth.connection,
         request_params: authentication_params
       )
       post_token_service.perform
-      store_credentials(post_token_service)
+      store_credentials(post_token_service, request_time)
     end
 
     private
 
-    def store_credentials(post_token_service)
+    def store_credentials(post_token_service, request_time)
       response_hash = post_token_service.parsed_response_body
 
       session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
       session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
+
+      session[:access_token_expires_in] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
+      session[:refresh_token_expires_in] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
     end
   end
 end

--- a/app/services/keycloak_oauth/authentication_service.rb
+++ b/app/services/keycloak_oauth/authentication_service.rb
@@ -31,8 +31,8 @@ module KeycloakOauth
       session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
       session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
 
-      session[:access_token_expires_in] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
-      session[:refresh_token_expires_in] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
+      session[:access_token_expires_at] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
+      session[:refresh_token_expires_at] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
     end
   end
 end

--- a/app/services/keycloak_oauth/authentication_service.rb
+++ b/app/services/keycloak_oauth/authentication_service.rb
@@ -11,7 +11,7 @@ module KeycloakOauth
     end
 
     def authenticate
-      post_token_service = KeycloakOauth::PostTokenService.new(
+      post_token_service = KeycloakOauth::PostAuthorizationCodeService.new(
         connection: KeycloakOauth.connection,
         request_params: authentication_params
       )

--- a/app/services/keycloak_oauth/authentication_service.rb
+++ b/app/services/keycloak_oauth/authentication_service.rb
@@ -1,38 +1,24 @@
 module KeycloakOauth
-  class AuthenticationService
-    ACCESS_TOKEN_KEY = 'access_token'.freeze
-    ACCESS_TOKEN_EXPIRES_IN = 'expires_in'.freeze
-    REFRESH_TOKEN_KEY = 'refresh_token'.freeze
-    REFRESH_TOKEN_EXPIRES_IN = 'refresh_expires_in'.freeze
+  class AuthenticationService < AuthenticationServiceBase
 
-    attr_reader :session, :authentication_params
+    attr_reader :authentication_params
 
-    def initialize(authentication_params:, session:)
+    def initialize(session:, authentication_params:)
       @authentication_params = authentication_params
-      @session = session
-    end
-
-    def authenticate
-      request_time = Time.zone.now
-
-      post_token_service = KeycloakOauth::PostAuthorizationCodeService.new(
-        connection: KeycloakOauth.connection,
-        request_params: authentication_params
-      )
-      post_token_service.perform
-      store_credentials(post_token_service, request_time)
+      super session: session
     end
 
     private
 
-    def store_credentials(post_token_service, request_time)
-      response_hash = post_token_service.parsed_response_body
+    def post_service_name
+      KeycloakOauth::PostAuthorizationCodeService
+    end
 
-      session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
-      session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
-
-      session[:access_token_expires_at] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
-      session[:refresh_token_expires_at] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
+    def post_service_arguments
+      {
+        connection: KeycloakOauth.connection,
+        request_params: authentication_params
+      }
     end
   end
 end

--- a/app/services/keycloak_oauth/authentication_service_base.rb
+++ b/app/services/keycloak_oauth/authentication_service_base.rb
@@ -1,0 +1,42 @@
+module KeycloakOauth
+  class AuthenticationServiceBase
+    ACCESS_TOKEN_KEY = 'access_token'.freeze
+    ACCESS_TOKEN_EXPIRES_IN = 'expires_in'.freeze
+    REFRESH_TOKEN_KEY = 'refresh_token'.freeze
+    REFRESH_TOKEN_EXPIRES_IN = 'refresh_expires_in'.freeze
+
+    attr_reader :session
+
+    def initialize(session:)
+      @session = session
+    end
+
+    def authenticate
+      request_time = Time.zone.now
+      post_token_service = post_service_name.new(**post_service_arguments)
+      post_token_service.perform
+      store_credentials_in_session(post_token_service, request_time)
+    end
+
+    private
+
+    def post_service_name
+      raise "Implement in subclass"
+    end
+
+    def post_service_arguments
+      raise "Implement in subclass"
+    end
+
+
+    def store_credentials_in_session(post_token_service, request_time)
+      response_hash = post_token_service.parsed_response_body
+
+      session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
+      session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
+
+      session[:access_token_expires_at] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
+      session[:refresh_token_expires_at] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
+    end
+  end
+end

--- a/app/services/keycloak_oauth/post_authorization_code_service.rb
+++ b/app/services/keycloak_oauth/post_authorization_code_service.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 
 module KeycloakOauth
-  class PostTokenService < KeycloakOauth::AuthorizableService
+  class PostAuthorizationCodeService < KeycloakOauth::AuthorizableService
     DEFAULT_GRANT_TYPE = 'authorization_code'.freeze
 
     attr_reader :request_params, :connection

--- a/app/services/keycloak_oauth/post_refresh_token_service.rb
+++ b/app/services/keycloak_oauth/post_refresh_token_service.rb
@@ -1,0 +1,41 @@
+require 'net/http'
+
+module KeycloakOauth
+  class PostRefreshTokenService < KeycloakOauth::AuthorizableService
+    DEFAULT_GRANT_TYPE = 'refresh_token'.freeze
+
+    attr_reader :request_params, :connection
+
+    def initialize(connection:, refresh_token:)
+      @connection = connection
+      @refresh_token = refresh_token
+    end
+
+    def send_request
+      post_token
+    end
+
+    private
+
+    attr_reader :connection, :refresh_token
+
+    def post_token
+      uri = URI.parse(connection.authentication_endpoint)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Post.new(uri)
+        request.set_content_type(CONTENT_TYPE_X_WWW_FORM_URLENCODED)
+        request.set_form_data(token_request_params)
+        http.request(request)
+      end
+    end
+
+    def token_request_params
+      {
+        client_id: connection.client_id,
+        client_secret: connection.client_secret,
+        grant_type: DEFAULT_GRANT_TYPE,
+        refresh_token: @refresh_token
+      }
+    end
+  end
+end

--- a/app/services/keycloak_oauth/post_refresh_token_service.rb
+++ b/app/services/keycloak_oauth/post_refresh_token_service.rb
@@ -4,8 +4,6 @@ module KeycloakOauth
   class PostRefreshTokenService < KeycloakOauth::AuthorizableService
     DEFAULT_GRANT_TYPE = 'refresh_token'.freeze
 
-    attr_reader :request_params, :connection
-
     def initialize(connection:, refresh_token:)
       @connection = connection
       @refresh_token = refresh_token
@@ -34,7 +32,7 @@ module KeycloakOauth
         client_id: connection.client_id,
         client_secret: connection.client_secret,
         grant_type: DEFAULT_GRANT_TYPE,
-        refresh_token: @refresh_token
+        refresh_token: refresh_token
       }
     end
   end

--- a/app/services/keycloak_oauth/refresh_authentication_service.rb
+++ b/app/services/keycloak_oauth/refresh_authentication_service.rb
@@ -1,37 +1,21 @@
 module KeycloakOauth
-  class RefreshAuthenticationService
-    ACCESS_TOKEN_KEY = 'access_token'.freeze
-    ACCESS_TOKEN_EXPIRES_IN = 'expires_in'.freeze
-    REFRESH_TOKEN_KEY = 'refresh_token'.freeze
-    REFRESH_TOKEN_EXPIRES_IN = 'refresh_expires_in'.freeze
-
-    attr_reader :session
+  class RefreshAuthenticationService < AuthenticationServiceBase
 
     def initialize(session:)
-      @session = session
-    end
-
-    def authenticate
-      request_time = Time.zone.now
-
-      post_refresh_token_service = KeycloakOauth::PostRefreshTokenService.new(
-        connection: KeycloakOauth.connection,
-        refresh_token: session[:refresh_token]
-      )
-      post_refresh_token_service.perform
-      update_session_information(post_refresh_token_service, request_time)
+      super
     end
 
     private
 
-    def update_session_information(post_token_service, request_time)
-      response_hash = post_token_service.parsed_response_body
+    def post_service_name
+      KeycloakOauth::PostRefreshTokenService
+    end
 
-      session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
-      session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
-
-      session[:access_token_expires_at] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
-      session[:refresh_token_expires_at] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
+    def post_service_arguments
+      {
+        connection: KeycloakOauth.connection,
+        refresh_token: session[:refresh_token]
+      }
     end
   end
 end

--- a/app/services/keycloak_oauth/refresh_authentication_service.rb
+++ b/app/services/keycloak_oauth/refresh_authentication_service.rb
@@ -16,7 +16,7 @@ module KeycloakOauth
 
       post_refresh_token_service = KeycloakOauth::PostRefreshTokenService.new(
         connection: KeycloakOauth.connection,
-        refresh_token: @session[:refresh_token]
+        refresh_token: session[:refresh_token]
       )
       post_refresh_token_service.perform
       update_session_information(post_refresh_token_service, request_time)

--- a/app/services/keycloak_oauth/refresh_authentication_service.rb
+++ b/app/services/keycloak_oauth/refresh_authentication_service.rb
@@ -1,0 +1,37 @@
+module KeycloakOauth
+  class RefreshAuthenticationService
+    ACCESS_TOKEN_KEY = 'access_token'.freeze
+    ACCESS_TOKEN_EXPIRES_IN = 'expires_in'.freeze
+    REFRESH_TOKEN_KEY = 'refresh_token'.freeze
+    REFRESH_TOKEN_EXPIRES_IN = 'refresh_expires_in'.freeze
+
+    attr_reader :session
+
+    def initialize(session:)
+      @session = session
+    end
+
+    def authenticate
+      request_time = Time.zone.now
+
+      post_refresh_token_service = KeycloakOauth::PostRefreshTokenService.new(
+        connection: KeycloakOauth.connection,
+        refresh_token: @session[:refresh_token]
+      )
+      post_refresh_token_service.perform
+      update_session_information(post_refresh_token_service, request_time)
+    end
+
+    private
+
+    def update_session_information(post_token_service, request_time)
+      response_hash = post_token_service.parsed_response_body
+
+      session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
+      session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
+
+      session[:access_token_expires_in] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
+      session[:refresh_token_expires_in] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
+    end
+  end
+end

--- a/app/services/keycloak_oauth/refresh_authentication_service.rb
+++ b/app/services/keycloak_oauth/refresh_authentication_service.rb
@@ -30,8 +30,8 @@ module KeycloakOauth
       session[:access_token] = response_hash[ACCESS_TOKEN_KEY]
       session[:refresh_token] = response_hash[REFRESH_TOKEN_KEY]
 
-      session[:access_token_expires_in] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
-      session[:refresh_token_expires_in] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
+      session[:access_token_expires_at] = request_time + response_hash[ACCESS_TOKEN_EXPIRES_IN].to_i.seconds
+      session[:refresh_token_expires_at] = request_time + response_hash[REFRESH_TOKEN_EXPIRES_IN].to_i.seconds
     end
   end
 end

--- a/keycloak_oauth.gemspec
+++ b/keycloak_oauth.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'combustion'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'timecop'
 end

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe KeycloakOauth::CallbacksController, type: :controller do
     context 'when the host app overwrites after_sign_in_path' do
       it 'maps user and redirects to the specified path' do
         stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
-          to_return(body: keycloak_tokens_request_body)
+          to_return(body: keycloak_authorization_code_body)
         stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
           to_return(body: keycloak_user_info_request_body)
 
@@ -26,7 +26,7 @@ RSpec.describe KeycloakOauth::CallbacksController, type: :controller do
     context 'when the host app does not overwrite after_sign_in_path' do
       it 'redirects to root path' do
         stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
-          to_return(body: keycloak_tokens_request_body)
+          to_return(body: keycloak_authorization_code_body)
         stub_request(:get, 'http://domain/auth/realms/first_realm/protocol/openid-connect/userinfo').
           to_return(body: keycloak_user_info_request_body)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ENV'] ||= 'test'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'timecop'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe KeycloakOauth::AuthenticationService do
         expect(service.session.access_token).to eq(access_token)
         expect(service.session.refresh_token).to eq(refresh_token)
 
-        expect(service.session.access_token_expires_in).to eq(Time.new(2022, 1, 1, 9, 6, 5, "+01:00"))
-        expect(service.session.refresh_token_expires_in).to eq(Time.new(2022, 1, 1, 0, 30, 0, "+01:00"))
+        expect(service.session.access_token_expires_at).to eq(Time.new(2022, 1, 1, 9, 6, 5, "+01:00"))
+        expect(service.session.refresh_token_expires_at).to eq(Time.new(2022, 1, 1, 0, 30, 0, "+01:00"))
       end
     end
 

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe KeycloakOauth::AuthenticationService do
 
       it 'retrieves authentication information and stores it in session' do
         stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
-          to_return(body: keycloak_tokens_request_body)
+          to_return(body: keycloak_authorization_code_body)
 
         service = subject
         service.authenticate

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -20,10 +20,15 @@ RSpec.describe KeycloakOauth::AuthenticationService do
           to_return(body: keycloak_authorization_code_body)
 
         service = subject
-        service.authenticate
+        Timecop.freeze(Time.new(2022, 1, 1, 0, 0, 0, "+01:00")) do
+          service.authenticate
+        end
 
         expect(service.session.access_token).to eq(access_token)
         expect(service.session.refresh_token).to eq(refresh_token)
+
+        expect(service.session.access_token_expires_in).to eq(Time.new(2022, 1, 1, 9, 6, 5, "+01:00"))
+        expect(service.session.refresh_token_expires_in).to eq(Time.new(2022, 1, 1, 0, 30, 0, "+01:00"))
       end
     end
 
@@ -49,11 +54,3 @@ RSpec.describe KeycloakOauth::AuthenticationService do
     }
   end
 end
-
-
-
-
-
-
-
-

--- a/spec/services/post_authorization_code_service_spec.rb
+++ b/spec/services/post_authorization_code_service_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 require 'support/helpers/keycloak_responses'
 
-RSpec.describe KeycloakOauth::PostTokenService do
+RSpec.describe KeycloakOauth::PostAuthorizationCodeService do
   include Helpers::KeycloakResponses
 
   let(:service) do
-    KeycloakOauth::PostTokenService.new(
+    KeycloakOauth::PostAuthorizationCodeService.new(
       connection: connection,
       request_params: dummy_request_params
     )
@@ -26,7 +26,7 @@ RSpec.describe KeycloakOauth::PostTokenService do
             code: dummy_request_params[:code],
             redirect_uri: dummy_request_params[:redirect_uri],
             session_state: dummy_request_params[:session_state]
-          }).to_return(body: keycloak_tokens_request_body)
+          }).to_return(body: keycloak_authorization_code_body)
 
         subject
 
@@ -79,7 +79,7 @@ RSpec.describe KeycloakOauth::PostTokenService do
             client_id: 'admin-cli',
             client_secret: 'some-admin-secret',
             grant_type: 'client_credentials'
-          }).to_return(body: keycloak_tokens_request_body)
+          }).to_return(body: keycloak_authorization_code_body)
 
         subject
 
@@ -101,7 +101,7 @@ RSpec.describe KeycloakOauth::PostTokenService do
 
     context 'when an access token is passed in' do
       let(:service) do
-        KeycloakOauth::PostTokenService.new(
+        KeycloakOauth::PostAuthorizationCodeService.new(
           connection: connection,
           access_token: 'some_access_token',
           request_params: dummy_request_params
@@ -111,7 +111,7 @@ RSpec.describe KeycloakOauth::PostTokenService do
       it 'sets the Authorization header' do
         stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token')
           .with(headers: { 'Authorization' => 'Bearer some_access_token'})
-          .to_return(body: keycloak_tokens_request_body)
+          .to_return(body: keycloak_authorization_code_body)
 
         subject
 

--- a/spec/services/post_refresh_token_service_spec.rb
+++ b/spec/services/post_refresh_token_service_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::PostAuthorizationCodeService do
+  include Helpers::KeycloakResponses
+
+  let(:service) do
+    KeycloakOauth::PostRefreshTokenService.new(
+      connection: connection,
+      refresh_token: refresh_token
+    )
+  end
+
+  describe '#send_request' do
+    let(:connection) { KeycloakOauth.connection }
+
+    subject { service.perform }
+
+    context 'when the refresh token can be exchanged for an access token' do
+      it 'retrieves authentication information' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token')
+          .with(body: {
+                  client_id: 'a_client',
+                  client_secret: 'a_secret',
+                  grant_type: 'refresh_token',
+                  refresh_token: refresh_token
+                }).to_return(body: keycloak_refresh_token_request_body)
+
+        subject
+
+        expect(service.http_response.code_type).to eq(Net::HTTPOK)
+        expect(service.parsed_response_body).to eq(
+          {
+            'access_token' => access_token,
+            'expires_in' => 60,
+            'refresh_expires_in' => 1800,
+            'refresh_token' => refresh_token,
+            'token_type' => 'Bearer',
+            'not-before-policy' => 0,
+            'session_state' => 'e4567259-6c07-4dd1-800b-d01692ed2634',
+            'scope' => 'email profile'
+          }
+        )
+      end
+    end
+
+    context 'when the refresh token is invalid/has expired' do
+      it 'returns error' do
+        faulty_service = KeycloakOauth::PostRefreshTokenService.new(
+          connection: connection,
+          refresh_token: 'refresh_token'
+        )
+
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token')
+          .with(body: {
+                  client_id: 'a_client',
+                  client_secret: 'a_secret',
+                  grant_type: 'refresh_token',
+                  refresh_token: 'refresh_token'
+                }).to_return(status: [400], body: keycloak_invalid_refresh_token_error_body)
+
+        expect { faulty_service.perform }.to raise_error(KeycloakOauth::AuthorizableError)
+      end
+    end
+
+    context 'when some default params are overridden' do
+      let(:dummy_request_params) { { grant_type: 'client_credentials' } }
+      let(:connection) do
+        KeycloakOauth::Connection.new(
+          auth_url: 'http://domain/auth',
+          realm: 'master',
+          client_id: 'admin-cli',
+          client_secret: 'some-admin-secret'
+        )
+      end
+
+      it 'retrieves authentication information' do
+        stub_request(:post, 'http://domain/auth/realms/master/protocol/openid-connect/token')
+          .with(body: {
+                  client_id: 'admin-cli',
+                  client_secret: 'some-admin-secret',
+                  grant_type: 'refresh_token',
+                  refresh_token: refresh_token
+                }).to_return(body: keycloak_refresh_token_request_body)
+
+        subject
+
+        expect(service.http_response.code_type).to eq(Net::HTTPOK)
+        expect(service.parsed_response_body).to eq(
+          {
+            'access_token' => access_token,
+            'expires_in' => 60,
+            'refresh_expires_in' => 1800,
+            'refresh_token' => refresh_token,
+            'token_type' => 'Bearer',
+            'not-before-policy' => 0,
+            'session_state' => 'e4567259-6c07-4dd1-800b-d01692ed2634',
+            'scope' => 'email profile'
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/post_refresh_token_service_spec.rb
+++ b/spec/services/post_refresh_token_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe KeycloakOauth::PostAuthorizationCodeService do
         expect(service.parsed_response_body).to eq(
           {
             'access_token' => access_token,
-            'expires_in' => 60,
+            'expires_in' => 32765,
             'refresh_expires_in' => 1800,
             'refresh_token' => refresh_token,
             'token_type' => 'Bearer',
@@ -89,7 +89,7 @@ RSpec.describe KeycloakOauth::PostAuthorizationCodeService do
         expect(service.parsed_response_body).to eq(
           {
             'access_token' => access_token,
-            'expires_in' => 60,
+            'expires_in' => 32765,
             'refresh_expires_in' => 1800,
             'refresh_token' => refresh_token,
             'token_type' => 'Bearer',

--- a/spec/services/refresh_authentication_service_spec.rb
+++ b/spec/services/refresh_authentication_service_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe KeycloakOauth::RefreshAuthenticationService do
         expect(service.session.access_token).to eq(access_token)
         expect(service.session.refresh_token).to eq(refresh_token)
 
-        expect(service.session.access_token_expires_in).to eq(Time.new(2022, 1, 1, 9, 6, 5, "+01:00"))
-        expect(service.session.refresh_token_expires_in).to eq(Time.new(2022, 1, 1, 0, 30, 0, "+01:00"))
+        expect(service.session.access_token_expires_at).to eq(Time.new(2022, 1, 1, 9, 6, 5, "+01:00"))
+        expect(service.session.refresh_token_expires_at).to eq(Time.new(2022, 1, 1, 0, 30, 0, "+01:00"))
       end
     end
 

--- a/spec/services/refresh_authentication_service_spec.rb
+++ b/spec/services/refresh_authentication_service_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'support/helpers/keycloak_responses'
+
+RSpec.describe KeycloakOauth::RefreshAuthenticationService do
+  include Helpers::KeycloakResponses
+
+  describe '#perform' do
+    subject do
+      KeycloakOauth::RefreshAuthenticationService.new(
+        session: session
+      )
+    end
+
+    context 'when the refresh token can be exchanged for an access token' do
+      let(:session) { OpenStruct.new(existing_session_param: 'some_param') }
+
+      it 'retrieves authentication information and stores it in session' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
+          to_return(body: keycloak_refresh_token_request_body)
+
+        service = subject
+        Timecop.freeze(Time.new(2022, 1, 1, 0, 0, 0, "+01:00")) do
+          service.authenticate
+        end
+
+        expect(service.session.access_token).to eq(access_token)
+        expect(service.session.refresh_token).to eq(refresh_token)
+
+        expect(service.session.access_token_expires_in).to eq(Time.new(2022, 1, 1, 9, 6, 5, "+01:00"))
+        expect(service.session.refresh_token_expires_in).to eq(Time.new(2022, 1, 1, 0, 30, 0, "+01:00"))
+      end
+    end
+
+    context 'when the authorization code is invalid/has expired' do
+      let(:session) { OpenStruct.new }
+
+      it 'raises an error' do
+        stub_request(:post, 'http://domain/auth/realms/first_realm/protocol/openid-connect/token').
+          to_return(status: [400], body: keycloak_invalid_refresh_token_error_body)
+
+        expect { subject.authenticate }.to raise_error(KeycloakOauth::AuthorizableError)
+      end
+    end
+  end
+end

--- a/spec/support/helpers/keycloak_responses.rb
+++ b/spec/support/helpers/keycloak_responses.rb
@@ -48,7 +48,7 @@ module Helpers
     end
 
     def keycloak_refresh_token_request_body
-      "{\"access_token\":\"#{access_token}\",\"expires_in\":60,\"refresh_expires_in\":1800,\"" \
+      "{\"access_token\":\"#{access_token}\",\"expires_in\":32765,\"refresh_expires_in\":1800,\"" \
       "refresh_token\":\"#{refresh_token}\",\"token_type\":\"Bearer\",\"not-before-policy\":0,\"" \
       "session_state\":\"e4567259-6c07-4dd1-800b-d01692ed2634\",\"scope\":\"email profile\"}"
     end

--- a/spec/support/helpers/keycloak_responses.rb
+++ b/spec/support/helpers/keycloak_responses.rb
@@ -1,6 +1,6 @@
 module Helpers
   module KeycloakResponses
-    def keycloak_tokens_request_body
+    def keycloak_authorization_code_body
       "{\"access_token\":\"#{access_token}\"," \
       "\"expires_in\":32765,\"refresh_expires_in\":1800,\"refresh_token\":\"" \
       "#{refresh_token}\",\"token_type\":\"bearer\",\"not-before-policy\":0," \
@@ -34,6 +34,10 @@ module Helpers
       "{\"error\":\"invalid_token\",\"error_description\":\"Token invalid: Failed to parse JWT\"}"
     end
 
+    def keycloak_invalid_refresh_token_error_body
+      "{\"error\":\"invalid_grant\",\"error_description\":\"Invalid refresh token\"}"
+    end
+
     def keycloak_users_request_body
       "[{\"id\":\"fd62fb4e-04e1-4660-a961-f4592b95bb45\",\"createdTimestamp\":1606123457175" \
       ",\"username\":\"user_A\",\"enabled\":true,\"totp\":false,\"" \
@@ -41,6 +45,12 @@ module Helpers
       "\"User A Last Name\",\"email\":\"user_A@example.com\",\"disableableCredentialTypes\":[]" \
       ",\"requiredActions\":[],\"notBefore\":0,\"access\":{\"manageGroupMembership\":true" \
       ",\"view\":true,\"mapRoles\":true,\"impersonate\":false,\"manage\":true}}]"
+    end
+
+    def keycloak_refresh_token_request_body
+      "{\"access_token\":\"#{access_token}\",\"expires_in\":60,\"refresh_expires_in\":1800,\"" \
+      "refresh_token\":\"#{refresh_token}\",\"token_type\":\"Bearer\",\"not-before-policy\":0,\"" \
+      "session_state\":\"e4567259-6c07-4dd1-800b-d01692ed2634\",\"scope\":\"email profile\"}"
     end
   end
 end


### PR DESCRIPTION
This PR implements a new workflow described in #28 : once an access token expires, it can be refreshed based on a `refresh_token`. 

The PR also contains a breaking change: `PostTokenService` is renamed to a `PostAuthorizationCodeService`