### PR TITLE
Redirect to `root_path` if `after_sign_in_path` is not overwritten

### DIFF
--- a/app/controllers/keycloak_oauth/callbacks_controller.rb
+++ b/app/controllers/keycloak_oauth/callbacks_controller.rb
@@ -12,7 +12,7 @@ module KeycloakOauth
       authentication_service.authenticate
       map_authenticatable_if_implemented(session)
 
-      redirect_to self.class.method_defined?(:after_sign_in_path) ? after_sign_in_path(request) : '/'
+      redirect_to self.class.method_defined?(:after_sign_in_path) ? after_sign_in_path(request) : main_app.root_path
     end
 
     private


### PR DESCRIPTION
This fixes an issue when `config.relative_url_root` is set in the `main_app`.

Closes #31.