### PR TITLE
Extract error classes into separate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-06-16
+
+### Changed
+
+- Extracted `KeycloakOauth::NotFoundError` and `KeycloakOauth::AuthorizableError` into separate file. When using Zeitwerk code loader in your main application, it was sometimes unable to find these classes.
+
 ## [2.0.0] - 2022-06-14
 
 ### Breaking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keycloak_oauth (2.0.0)
+    keycloak_oauth (2.0.1)
       rails (>= 6.0)
 
 GEM

--- a/app/services/keycloak_oauth/authorizable_error.rb
+++ b/app/services/keycloak_oauth/authorizable_error.rb
@@ -1,0 +1,3 @@
+module KeycloakOauth
+  class AuthorizableError < StandardError; end
+end

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -1,3 +1,5 @@
+require 'keycloak_oauth/authorizable_error'
+require 'keycloak_oauth/not_found_error'
 require 'net/http'
 
 module KeycloakOauth

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -1,9 +1,6 @@
 require 'net/http'
 
 module KeycloakOauth
-  class AuthorizableError < StandardError; end
-  class NotFoundError < StandardError; end
-
   class AuthorizableService
     HTTP_SUCCESS_CODES = [Net::HTTPOK, Net::HTTPNoContent, Net::HTTPCreated]
     CONTENT_TYPE_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded'.freeze

--- a/app/services/keycloak_oauth/not_found_error.rb
+++ b/app/services/keycloak_oauth/not_found_error.rb
@@ -1,0 +1,3 @@
+module KeycloakOauth
+  class NotFoundError < StandardError; end
+end

--- a/lib/keycloak_oauth/version.rb
+++ b/lib/keycloak_oauth/version.rb
@@ -1,3 +1,3 @@
 module KeycloakOauth
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
Using Rails 7 and Zeitwerk activated, I sometimes ran into the following issue `NameError: uninitialized constant KeycloakOauth::AuthorizableError`. Running `rails zeitwerk:check` in the host application confirmed that Zeitwerk was unable to find those error classes when referencing them:

```shell
Andys-MacBook-Pro:application apf$ rails zeitwerk:check
Hold on, I am eager loading the application.
rails aborted!
NameError: uninitialized constant KeycloakOauth::AuthorizableError
Did you mean?  KeycloakOauth::AuthorizableService
/Users/apf/dev/client/application/app/controllers/base_controller.rb:10:in `<class:BaseController>'
/Users/apf/dev/client/application/app/controllers/base_controller.rb:1:in `<main>'
Tasks: TOP => zeitwerk:check
```

Extracting the error classes into separate files and updating the gem in this application to this feature branch solved the issue:

```shell
Andys-MacBook-Pro:application apf$ rails zeitwerk:check
Hold on, I am eager loading the application.
All is good!
```