### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you are calling Keycloak in your `ApplicationController`, for example, as a c
   end
 ```
 
-you may get into infinite loop issue, because  `KeycloakOauth::CallbacksController` also inherits from the `ApplicationController` and keeps redirecting to authentication endpoint. As a workaround you could call the Keycloak endpoint from the `BaseController`, that would inherit from `ApplicationController`.
+you may get into infinite loop issue, because  `KeycloakOauth::CallbacksController` also inherits from the `ApplicationController` and keeps redirecting to authentication endpoint. As a workaround, create a `BaseController` from which the controllers in your application inherit and move the `authenticate` callback to it.
 
 ### Customising redirect URIs
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ e.g.
 
 Once authentication is performed, the access and refresh tokens are stored in the session and can be used in your app as wished. As the session can become larger than we can store in a cookie (`CookieOverflow` exception), we recommend to use [activerecord-session_store](https://github.com/rails/activerecord-session_store).
 
-If you are calling Keycloak in your `ApplicationController`, for exmaple, as a callback:
+If you are calling Keycloak in your `ApplicationController`, for example, as a callback:
 
 ```ruby
   before_action :authenticate_with_keycloak


### PR DESCRIPTION
I updated documentation:
- added missing `refresh_token` for `get_user_information` method
- described a workaround for the infinite loop issue when calling Keycloak endpoint from `ApplicationController`