### PR TITLE
Use `require_relative` for gem-internal files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Extracted `KeycloakOauth::DuplicationError` into a separate file to please the Zeitwerk loader.
+- Use `require_relative` for load gem-internal files.
 
 ## [2.0.1] - 2022-06-16
 

--- a/app/services/keycloak_oauth/authorizable_service.rb
+++ b/app/services/keycloak_oauth/authorizable_service.rb
@@ -1,6 +1,7 @@
-require 'keycloak_oauth/authorizable_error'
-require 'keycloak_oauth/not_found_error'
 require 'net/http'
+
+require_relative "authorizable_error"
+require_relative "not_found_error"
 
 module KeycloakOauth
   class AuthorizableService

--- a/app/services/keycloak_oauth/post_users_service.rb
+++ b/app/services/keycloak_oauth/post_users_service.rb
@@ -1,6 +1,7 @@
 require 'net/http'
-require 'keycloak_oauth/authorizable_error'
-require 'keycloak_oauth/duplication_error'
+
+require_relative 'authorizable_error'
+require_relative 'not_found_error'
 
 module KeycloakOauth
   class PostUsersService < KeycloakOauth::AuthorizableService

--- a/lib/keycloak_oauth.rb
+++ b/lib/keycloak_oauth.rb
@@ -1,7 +1,7 @@
-require 'keycloak_oauth/version'
-require 'keycloak_oauth/configuration'
-require 'keycloak_oauth/connection'
-require 'keycloak_oauth/engine'
+require_relative 'keycloak_oauth/version'
+require_relative 'keycloak_oauth/configuration'
+require_relative 'keycloak_oauth/connection'
+require_relative 'keycloak_oauth/engine'
 
 module KeycloakOauth
   def self.configure

--- a/lib/keycloak_oauth/connection.rb
+++ b/lib/keycloak_oauth/connection.rb
@@ -1,4 +1,4 @@
-require 'keycloak_oauth/endpoints'
+require_relative 'endpoints'
 
 module KeycloakOauth
   class Connection


### PR DESCRIPTION
We see strange loading errors on a Rails 7.1 application, where Zeitwerk is unable to find files for the gem. `require_relative` should fix these issues.