### PR TITLE
Keep bundler below v2.5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>simplificator/renovate-preset"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "bundler"
+      ],
+      "allowedVersions": "<2.5"
+    }
   ]
 }


### PR DESCRIPTION
v2.5 dropped support for Ruby v2.6:
https://github.com/rubygems/rubygems/blob/HEAD/bundler/CHANGELOG.md#250-december-15-2023